### PR TITLE
Turned On Multi-CPU VirtualBox Flag. Dramatically improves performance!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Instructions:
 #### Requirements
 In order to successfully run the `Vagrantfile` your laptop will need the following:
 
- - 8GiB of RAM
+ - 4GiB of RAM
+   -  8GiB will give better performance  
    -  Change the [`memory`](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/Vagrantfile#L15) setting in the `Vagrantfile`
  - 20GiB of free disk space
  - VirtualBox 5.1.28 [Download](https://www.virtualbox.org/wiki/Downloads)
@@ -43,13 +44,14 @@ The included `Vagrantfile` defines a single Ubuntu 16.04 VM. On that VM we insta
 
 Once the `Vagrantfile` has installed and configured [LXD](https://www.ubuntu.com/containers/lxd) and installed all of the IBM Cloud Private community edition prereqs on the VM and all LXD containers defined within, it will begin the process of installing IBM Cloud Private community edition. This process should take about 20-30 mins to complete. Once done you will be able to access the IBM Cloud Private community edition web console here: [https://192.168.27.100:8443](https://192.168.27.100:8443) (assuming you did not have to change the [`base_segment`](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/Vagrantfile#L28) value in the `Vagrantfile` see `Conflicting Network Segments` section below for details)  
 
-This `Vagrantfile` will stand up a single [VirtualBox](https://www.virtualbox.org/wiki/Downloads) VM and deploy the `master` and `proxy` nodes onto it. It will configure and start two additional `lxc` containers within the [VirtualBox](https://www.virtualbox.org/wiki/Downloads) VM and install the `worker` nodes onto them (`cfc-worker1` & `cfc-worker2`). The `cpu` and `memory` allocated in the `Vagrantfile` will be shared by the VM and the `lxc` containers running the `worker` nodes within it. You can check the status of the `lxc` instances by ssh'ing into the VM using `vagrant ssh` and then running the command `lxc list`:  
+This `Vagrantfile` will stand up a single [VirtualBox](https://www.virtualbox.org/wiki/Downloads) VM and deploy the `master` and `proxy` nodes onto it. It will configure and start three additional `lxc` containers within the [VirtualBox](https://www.virtualbox.org/wiki/Downloads) VM and install the `worker` nodes onto two of them (`cfc-worker1` & `cfc-worker2`) and the management services onto the third (`cfc-manager1`). The `cpu` and `memory` allocated in the `Vagrantfile` will be shared by the VM and the `lxc` containers running the `worker` nodes within it. You can check the status of the `lxc` instances by ssh'ing into the VM using `vagrant ssh` and then running the command `lxc list`:  
 
 
 | NAME        | STATE   | IPV4                           | IPV6 | TYPE       | SNAPSHOTS |  
 | ----------- | ------- | ------------------------------ | ---- | ---------- | --------- |
 | cfc-worker1 | RUNNING | 192.168.27.101 (eth0) 172.17.0.1 (docker0) 10.1.213.128 (tunl0)|      | PERSISTENT | 0         |   
 | cfc-worker2 | RUNNING | 192.168.27.102 (eth0) 172.17.0.1 (docker0) 10.1.54.64 (tunl0)  |      | PERSISTENT | 0         |  
+| cfc-manager1 | RUNNING | 192.168.27.111 (eth0) 172.17.0.1 (docker0) 10.1.16.98 (tunl0)  |      | PERSISTENT | 0         |  
 
 #### Conflicting Network Segments
 If you see the addresses `192.168.56.101` or `192.168.56.102` for either `cfc-worker1` or `cfc-worker2` that means there was a conflicting network segment for the `192.168.27.x` network on your system. You will need to change the `base_segment` value in the `Vagrantfile` to a value that will not overlap any existing segments on your machine. See the comments in the `Vagrantfile` for [examples](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/Vagrantfile#L24-L28)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -188,13 +188,13 @@ SCRIPT
 
 configure_swap_space = <<SCRIPT
 sudo rm -f /mnt/swap
-sudo fallocate -l 4g /mnt/swap
+sudo fallocate -l 8g /mnt/swap
 sudo chmod 600 /mnt/swap
 sudo mkswap /mnt/swap
 sudo swapon /mnt/swap
 echo "/mnt/swap swap swap defaults 0 0" | sudo tee --append /etc/fstab > /dev/null
-echo "vm.swappiness = 40" | sudo tee --append /etc/sysctl.conf > /dev/null
-echo "vm.vfs_cache_pressure = 50" | sudo tee --append /etc/sysctl.conf > /dev/null
+echo "vm.swappiness = 60" | sudo tee --append /etc/sysctl.conf > /dev/null
+echo "vm.vfs_cache_pressure = 10" | sudo tee --append /etc/sysctl.conf > /dev/null
 sudo sysctl -p
 SCRIPT
 
@@ -590,8 +590,8 @@ echo "This may take a few minutes depending on your connection speed and reliabi
 echo "Pre-caching docker images...."
 echo "Pulling #{image_repo}/icp-inception:#{version}..."
 docker pull #{image_repo}/icp-inception:#{version} &> /dev/null
-echo "Pulling #{image_repo}/icp-cloudantdb:#{version}..."
-docker pull #{image_repo}/cloudantdb:#{version} &> /dev/null
+echo "Pulling #{image_repo}/icp-datastore:#{version}..."
+docker pull #{image_repo}/icp-datastore:#{version} &> /dev/null
 echo "Pulling #{image_repo}/icp-platform-auth:#{version}..."
 docker pull #{image_repo}/icp-platform-auth:#{version} &> /dev/null
 echo "Pulling #{image_repo}/icp-auth:#{version}..."
@@ -937,7 +937,7 @@ Vagrant.configure(2) do |config|
     icp.vm.provider "virtualbox" do |virtualbox|
       virtualbox.name = "#{vm_name}"
       virtualbox.gui = false
-      virtualbox.customize ["modifyvm", :id, "--ioapic", "off"] # turn off I/O APIC
+      virtualbox.customize ["modifyvm", :id, "--ioapic", "on"] # turn off I/O APIC
       virtualbox.customize ["modifyvm", :id, "--cpus", "#{cpus}"] # set number of vcpus
       virtualbox.customize ["modifyvm", :id, "--memory", "#{memory}"] # set amount of memory allocated vm memory
       virtualbox.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"] # set guest OS type


### PR DESCRIPTION
- Turned on multi-cpu support by setting the `--ioapic` VirtualBox management flag to "on"
- Upped the swap size from 4GiB to 8GiB and tuned the "swappiness" setting to 60
- Now pre-pulling the correct image for cloudantdb (it's not called icp-datastore)