### PR TITLE
Added deployment steps for Terraform and OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Instructions:
 * [Deploy in local VMs using Vagrant](#deploy-using-vagrant)
 * [Deploy in Softlayer VMs using Ansible](#deploy-on-ibm-cloud-softlayer)
+* [Deploy in OpenStack using Terraform](#deploy-using-openstack-and-terraform)
 
 
 ## Deploy using Vagrant:
@@ -262,3 +263,8 @@ NAME             STATUS                     AGE       VERSION
 ```
 
 From here you should be able to interact with ICP via either the Web UI or the `kubectl` command.
+
+## deploy-using-openstack-and-terraform
+
+Please refer to the embedded README document in *terraform_modules/openstack*
+for detailed deployment steps.

--- a/terraform_modules/openstack/README.rst
+++ b/terraform_modules/openstack/README.rst
@@ -1,0 +1,49 @@
+=======
+Summary
+=======
+
+This Terraform sample will perform a simple IBM Cloud Private (ICP) deployment
+using the Community Edition. It is currently setup to deploy an ICP master node
+(also serves as the boot and proxy node) and a user-configurable number of ICP
+worker nodes. This sample does not supersede the official ICP deployment
+instructions, it merely serves as a simple way to provision an ICP cluster
+atop your OpenStack-based infrastructure for experimental purposes.
+
+Assumptions
+-----------
+* It is assumed that the reader is already familiar with IBM Cloud private;
+  if you are not, please refer to the `ICP Community
+  <https://www.ibm.com/developerworks/community/wikis/home?lang=en#!/wiki/W1559b1be149d_43b0_881e_9783f38faaff>`_
+
+Prerequisites
+-------------
+* You have `downloaded Terraform
+  <https://www.terraform.io/downloads.html>`_ and installed it on your workstation
+* You have an installation of OpenStack (or PowerVC) up and running; this
+  module has been confirmed to work on Ocata-based OpenStack deployments
+* You have an Ubuntu 16.04 image loaded within your OpenStack (or PowerVC)
+  environment; this will be used as the baseline virtual machine for all of the
+  ICP nodes
+
+Instructions
+------------
+* Download (i.e., **git clone**) all of the files in this module and place them
+  in an ICP directory on your Terraform workstation
+* On your Terraform workstation, generate an SSH key pair to be pushed (via
+  Terraform) to all of the nodes; e.g., you can [**ssh-keygen -t rsa**] to
+  create this from a Linux or macOS workstation (this will be referenced in
+  the subsequent step when you're updating **variables.tf**)
+* Edit the contents of **variables.tf** to align with your OpenStack (or
+  PowerVC) deployment (make sure you're using an OpenStack flavor with
+  sufficient resources; a minimum of 2 vcpus and 8 GB of memory is recommended)
+* Within **bootstrap_icp_master.sh**, change the *ICP_DOCKER_IMAGE*
+  (*ibmcom/cfc-installer* for x86 or *ppc64le/cfc-installer* for Power Systems)
+  and *ICP_VER* variables to align with your desired ICP architecture and version
+* Within **ibm-icp-deploy.tf**, change the value of the "count" variable to the
+  number of ICP worker nodes that you want to deploy; note that if you're
+  using this for anything beyond a proof-of-concept, please also take the
+  added step of setting *insecure=false* and set the *cacert* option as
+  appropriate for your OpenStack infrastructure
+* Run [**terraform apply -parallelism=2**] to start the ICP deployment
+* Sit back and relax... within about 20-30 minutes, you should be able to
+  access your ICP cluster at https://<ICP_MASTER_IP_ADDRESS>:8443

--- a/terraform_modules/openstack/bootstrap_icp_master.sh
+++ b/terraform_modules/openstack/bootstrap_icp_master.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright IBM Corp. 2017.
+#
+################################################################
+
+# The IBM Cloud Private Docker image to install
+# (ibmcom/cfc-installer for x86 or ppc64le/cfc-installer for Power Systems)
+ICP_DOCKER_IMAGE=ppc64le/cfc-installer
+# Version of IBM Cloud Private to install
+ICP_VER=1.2.0
+
+# Disable the firewall
+/usr/sbin/ufw disable
+# Enable NTP
+/usr/bin/timedatectl set-ntp on
+# Need to set vm.max_map_count to at least 262144
+/sbin/sysctl -w vm.max_map_count=262144
+# Prepare the system for updates, install Docker and install Python
+/usr/bin/apt update
+/usr/bin/apt-get --assume-yes install docker.io
+/usr/bin/apt-get --assume-yes install python
+/usr/bin/apt-get --assume-yes install interchange
+/bin/systemctl start docker
+
+# Ensure the hostnames are resolvable
+IP=`/sbin/ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}'`
+/bin/echo "${IP} $(hostname)" >> /etc/hosts
+
+# Configure IBM Cloud Private
+/usr/bin/docker pull ${ICP_DOCKER_IMAGE}:${ICP_VER}
+/bin/mkdir /opt/ibm-cloud-private-ce-${ICP_VER}
+cd /opt/ibm-cloud-private-ce-${ICP_VER}
+/usr/bin/docker run -e LICENSE=accept -v \
+    "$(pwd)":/data ${ICP_DOCKER_IMAGE}:${ICP_VER} cp -r cluster /data
+
+# Configure the master and proxy as the same node
+/bin/echo "[master]"  > cluster/hosts
+/bin/echo "${IP}"    >> cluster/hosts
+/bin/echo "[proxy]"  >> cluster/hosts
+/bin/echo "${IP}"    >> cluster/hosts
+# Configure the worker node(s)
+for worker_ip in $( cat /root/icp_worker_nodes.txt | sed 's/|/\n/g' ); do
+    /bin/echo "[worker]"     >> cluster/hosts
+    /bin/echo "${worker_ip}" >> cluster/hosts
+done
+
+# Setup the private key for the ICP cluster (injected at deploy time)
+/bin/cp /root/id_rsa.terraform \
+    /opt/ibm-cloud-private-ce-${ICP_VER}/cluster/ssh_key
+/bin/chmod 400 /opt/ibm-cloud-private-ce-${ICP_VER}/cluster/ssh_key
+
+# Deploy IBM Cloud Private
+cd /opt/ibm-cloud-private-ce-${ICP_VER}/cluster
+/usr/bin/docker run -e LICENSE=accept --net=host -t -v \
+    "$(pwd)":/installer/cluster ${ICP_DOCKER_IMAGE}:${ICP_VER} install
+
+exit 0

--- a/terraform_modules/openstack/bootstrap_icp_worker.sh
+++ b/terraform_modules/openstack/bootstrap_icp_worker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright IBM Corp. 2017.
+#
+################################################################
+
+# Disable the firewall
+/usr/sbin/ufw disable
+# Enable NTP
+/usr/bin/timedatectl set-ntp on
+# Need to set vm.max_map_count to at least 262144
+/sbin/sysctl -w vm.max_map_count=262144
+# Prepare the system for updates, install Docker and install Python
+/usr/bin/apt update
+/usr/bin/apt-get --assume-yes install docker.io
+/usr/bin/apt-get --assume-yes install python
+/bin/systemctl start docker
+
+# Ensure the hostname is resolvable
+IP=`/sbin/ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}'`
+/bin/echo "${IP} $(hostname)" >> /etc/hosts
+
+exit 0

--- a/terraform_modules/openstack/ibm-icp-deploy.tf
+++ b/terraform_modules/openstack/ibm-icp-deploy.tf
@@ -1,0 +1,79 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright IBM Corp. 2017.
+#
+################################################################
+
+provider "openstack" {
+    user_name   = "${var.openstack_user_name}"
+    password    = "${var.openstack_password}"
+    tenant_name = "${var.openstack_project_name}"
+    domain_name = "${var.openstack_domain_name}"
+    auth_url    = "${var.openstack_auth_url}"
+    insecure    = true
+}
+
+resource "openstack_compute_keypair_v2" "icp-key-pair" {
+    name       = "terraform-icp-key-pair"
+    public_key = "${file("${var.openstack_ssh_key_file}.pub")}"
+}
+
+variable "count" {
+    default = 3
+}
+
+resource "openstack_compute_instance_v2" "icp-worker-vm" {
+    count     = "${var.count}"
+    name      = "${format("terraform-icp-worker-%02d", count.index+1)}"
+    image_id  = "${var.openstack_image_id}"
+    flavor_id = "${var.openstack_flavor_id}"
+    key_pair  = "${openstack_compute_keypair_v2.icp-key-pair.name}"
+
+    network {
+        uuid = "${var.openstack_network_id}"
+        name = "${var.openstack_network_name}"
+    }
+
+    user_data = "${file("bootstrap_icp_worker.sh")}"
+}
+
+resource "openstack_compute_instance_v2" "icp-master-vm" {
+    name      = "terraform-icp-master"
+    image_id  = "${var.openstack_image_id}"
+    flavor_id = "${var.openstack_flavor_id}"
+    key_pair  = "${openstack_compute_keypair_v2.icp-key-pair.name}"
+
+    personality {
+        file    = "/root/id_rsa.terraform"
+        content = "${file("${var.openstack_ssh_key_file}")}"
+    }
+
+    personality {
+        file    = "/root/icp_worker_nodes.txt"
+        content = "${join("|", openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4)}"
+    }
+
+    network {
+        uuid = "${var.openstack_network_id}"
+        name = "${var.openstack_network_name}"
+    }
+
+    user_data = "${file("bootstrap_icp_master.sh")}"
+}
+
+output "icp-master-vm-ip" {
+    value = "${openstack_compute_instance_v2.icp-master-vm.network.0.fixed_ip_v4}"
+}
+
+output "icp-worker-vm-ip" {
+    value = "${openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4}"
+}

--- a/terraform_modules/openstack/variables.tf
+++ b/terraform_modules/openstack/variables.tf
@@ -1,0 +1,64 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright IBM Corp. 2017.
+#
+################################################################
+
+variable "openstack_user_name" {
+    description = "The user name used to connect to OpenStack."
+    default = "my_user_name"
+}
+
+variable "openstack_password" {
+    description = "The password for the user."
+    default = "my_password"
+}
+
+variable "openstack_project_name" {
+    description = "The name of the project (a.k.a. tenant) used."
+    default = "ibm-default"
+}
+
+variable "openstack_domain_name" {
+    description = "The domain to be used."
+    default = "Default"
+}
+
+variable "openstack_auth_url" {
+    description = "The endpoint URL used to connect to OpenStack."
+    default = "https://<HOSTNAME>:5000/v3/"
+}
+
+variable "openstack_image_id" {
+    description = "The ID of the image to be used for deploy operations."
+    default = "my_image_id"
+}
+
+variable "openstack_flavor_id" {
+    description = "The ID of the flavor to be used for deploy operations."
+    default = "my_flavor_id"
+}
+
+variable "openstack_network_id" {
+    description = "The ID of the network to be used for deploy operations."
+    default = "my_network_id"
+}
+
+variable "openstack_network_name" {
+    description = "The name of the network to be used for deploy operations."
+    default = "my_network_name"
+}
+
+variable "openstack_ssh_key_file" {
+    description = "The path to the SSH public key."
+    default = "<path to SSH key file>"
+}


### PR DESCRIPTION
This Terraform module allows an IBM Cloud Private cluster to be seamlessly deployed on top of any OpenStack environment; this can be used as a baseline for deploying atop either Power Systems (e.g., via PowerVC) or x86-based infrastructures.