### PR TITLE
Update download link for VirtualBox 5.1.28 with comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to successfully run the `Vagrantfile` your laptop will need the followi
    -  8GiB will give better performance  
    -  Change the [`memory`](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/Vagrantfile#L15) setting in the `Vagrantfile`
  - 20GiB of free disk space
- - VirtualBox 5.1.28 [Download](https://www.virtualbox.org/wiki/Downloads)
+ - VirtualBox 5.1.28 [Download](https://www.virtualbox.org/wiki/Download_Old_Builds_5_1) - VirtualBox 5.2 is not yet supported by Vagrant
  - Vagrant 2.0.0 [Download](https://www.vagrantup.com/downloads.html)
  - Operating Systems
    - Mac OSx 10.12.6


### PR DESCRIPTION
Added link to the 5.1 download page, and a comment in the README as to why 5.1..28 is needed (5.2 is not yet supported by Vagrant)

This tripped me up following the instructions.