### PR TITLE
add nfs-common package to ubuntu install

### DIFF
--- a/playbooks/prepare_sl_vms.yml
+++ b/playbooks/prepare_sl_vms.yml
@@ -49,7 +49,7 @@
     - name: install extra packages
       apt:
         name: "{{ item }}"
-      with_items: [dnsmasq,vim,python-pip]
+      with_items: [dnsmasq,vim,python-pip,nfs-common]
       when: ansible_os_family == 'Debian'
 
     - name: disable resolvconf updates


### PR DESCRIPTION
NFS can be used for storage in ICP.  this makes sure its available on the OS.