### PR TITLE
Remove outdated document reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,3 @@ NAME             STATUS                     AGE       VERSION
 ```
 
 From here you should be able to interact with ICP via either the Web UI or the `kubectl` command.
-
-## deploy-using-openstack-and-terraform
-
-Please refer to the embedded README document in *terraform/openstack*
-for detailed deployment steps.


### PR DESCRIPTION
The terraform/openstack directory no longer contains a README as
the information has been moved to the docs directory and is already
linked to at the beginning of the root README.  This patch removes
the outdated reference and the end of the root README.