### PR TITLE
add sl vlan and icp admin password specification

### DIFF
--- a/docs/deploy-softlayer-terraform.md
+++ b/docs/deploy-softlayer-terraform.md
@@ -16,6 +16,7 @@ editor and update the following variables to suit your environment:
 * key_name
 * key_file
 * datacenter
+* public and private vlan
 
 _Make sure the private key that matches your `key_name` is added to your ssh-agent._
 

--- a/terraform/ibmcloud/main.tf
+++ b/terraform/ibmcloud/main.tf
@@ -23,6 +23,8 @@ resource "softlayer_virtual_guest" "icpmaster" {
     network_speed         = "${var.master["network_speed"]}"
     hourly_billing        = "${var.master["hourly_billing"]}"
     private_network_only  = "${var.master["private_network_only"]}"
+    public_vlan_id        = "${var.public_vlan_id}"
+    private_vlan_id        = "${var.private_vlan_id}"
 
     user_metadata = "{\"value\":\"newvalue\"}"
 
@@ -45,6 +47,8 @@ resource "softlayer_virtual_guest" "icpworker" {
     network_speed         = "${var.worker["network_speed"]}"
     hourly_billing        = "${var.worker["hourly_billing"]}"
     private_network_only  = "${var.worker["private_network_only"]}"
+    public_vlan_id        = "${var.public_vlan_id}"
+    private_vlan_id        = "${var.private_vlan_id}"
 
     user_metadata = "{\"value\":\"newvalue\"}"
 
@@ -67,6 +71,8 @@ resource "softlayer_virtual_guest" "icpproxy" {
     network_speed         = "${var.proxy["network_speed"]}"
     hourly_billing        = "${var.proxy["hourly_billing"]}"
     private_network_only  = "${var.proxy["private_network_only"]}"
+    public_vlan_id        = "${var.public_vlan_id}"
+    private_vlan_id        = "${var.private_vlan_id}"
 
     user_metadata = "{\"value\":\"newvalue\"}"
 
@@ -91,10 +97,11 @@ module "icpprovision" {
 
     # Because SoftLayer private network uses 10.0.0.0/8 range,
     # we will override default ICP network configuration
-    # to be sure to avoid conflict
+    # to be sure to avoid conflict. Allow override of default admin password.
     icp_configuration = {
       "network_cidr"              = "192.168.0.0/16"
       "service_cluster_ip_range"  = "172.16.0.1/24"
+      "default_admin_password"    = "${var.default_admin_password}"
     }
 
     # We will let terraform generate a new ssh keypair

--- a/terraform/ibmcloud/variables.tf
+++ b/terraform/ibmcloud/variables.tf
@@ -15,12 +15,17 @@ variable "key_file" {
 ##### Common VM specifications ######
 variable "datacenter" { default = "dal10" }
 variable "domain" { default = "icp.demo" }
+variable "public_vlan_id" { default = ""}
+variable "private_vlan_id" { default = ""}
 
-##### ICP version #####
+##### ICP settings #####
 variable "icp_version" { default = "ibmcom/icp-inception:2.1.0-beta-3" }
 
 # Name of the ICP installation, will be used as basename for VMs
 variable "instance_name" { default = "myicp" }
+
+# Password to use for default admin user
+variable "default_admin_password" { default = "admin" }
 
 ##### ICP Instance details ######
 variable "master" {


### PR DESCRIPTION
When using terraform in SL, it's possible to end up with instances spread across VLANS in a DC. Avoid this by providing option to specify vlan id for public and private.

Allow users to customize admin user password.

For both changes, no action results in default behavior matching current repository.