### PR TITLE
Added support for the disabled_management_services:  configuration option.

### DIFF
--- a/terraform/openstack/bootstrap_icp_master.sh
+++ b/terraform/openstack/bootstrap_icp_master.sh
@@ -100,6 +100,12 @@ done
 if [ -n "${install_user_password}" ]; then
     /bin/sed -i 's/.*ansible_become_password:.*/ansible_become_password: "'${install_user_password}'"/g' cluster/config.yaml
 fi
+if [ -n "${icp_disabled_services}" ]; then
+	/bin/sed -i 's/.*disabled_management_services:.*/disabled_management_services: [ ${icp_disabled_services} ]/g' cluster/config.yaml
+else
+	/bin/sed -i 's/.*disabled_management_services:.*/#disabled_management_services: [ ${icp_disabled_services} ]/g' cluster/config.yaml
+
+fi
 
 # Setup the private key for the ICP cluster (injected at deploy time)
 /bin/cp /root/id_rsa.terraform \

--- a/terraform/openstack/bootstrap_icp_master.sh
+++ b/terraform/openstack/bootstrap_icp_master.sh
@@ -103,7 +103,7 @@ fi
 if [ -n "${icp_disabled_services}" ]; then
 	/bin/sed -i 's/.*disabled_management_services:.*/disabled_management_services: [ ${icp_disabled_services} ]/g' cluster/config.yaml
 else
-	/bin/sed -i 's/.*disabled_management_services:.*/#disabled_management_services: [ ${icp_disabled_services} ]/g' cluster/config.yaml
+	/bin/sed -i 's/.*disabled_management_services:.*/disabled_management_services: [ "" ]/g' cluster/config.yaml
 
 fi
 

--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -76,6 +76,7 @@ data "template_file" "bootstrap_init" {
         icp_architecture = "${var.icp_architecture}"
         icp_edition = "${var.icp_edition}"
         icp_download_location = "${var.icp_download_location}"
+	icp_disabled_services = "${join(", ",formatlist("\"%s\"",var.icp_disabled_services))}"
         install_user_name = "${var.icp_install_user}"
         install_user_password = "${var.icp_install_user_password}"
     }

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -97,3 +97,11 @@ variable "icp_download_location" {
     description = "HTTP wget location for ICP Enterprise Edition - ignored for community edition"
     default = "http://LOCATION_OF_ICP_ENTERPRISE_EDITION.tar.gz"
 }
+
+variable "icp_disabled_services" {
+    type = "list"
+    description = "List of ICP services to disable"
+    default = [
+	"va"
+    ]
+}

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -100,7 +100,7 @@ variable "icp_download_location" {
 
 variable "icp_disabled_services" {
     type = "list"
-    description = "List of ICP services to disable"
+    description = "List of ICP services to disable (e.g., va, monitoring or metering)"
     default = [
 	"va"
     ]


### PR DESCRIPTION
This PR adds a variable to allow specifying the disabled_management_services config.yaml option in the terraform variables. The current default is to disable "va", but can be overridden by the variable definition.