### PR TITLE
fix so that 127.0.1.1 is replaced too

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -531,7 +531,7 @@ $(curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sed  's/^/          
         type: nic
         ipv4.address: #{base_segment}.103
 EOF
-sudo sed -i 's/127.0.0.1\tmaster.icp/#{base_segment}.100\tmaster.icp/g' /etc/hosts
+sudo sed -i 's/127.0...1\tmaster.icp/#{base_segment}.100\tmaster.icp/g' /etc/hosts
 SCRIPT
 
 bring_up_icp_host_interface = <<SCRIPT


### PR DESCRIPTION
The host entry will be 127.0.1.1 and not 127.0.0.1, hence a wildcard is needed.
This is required as the host-entry is 127.0.1.1 when running vagrant up on my Mac for the current tree, using a wildcard fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/deploy-ibm-cloud-private/106)
<!-- Reviewable:end -->
