### PR TITLE
ICP 2.1.0.3 support for terraform

### DIFF
--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -77,8 +77,9 @@ data "template_file" "bootstrap_init" {
         icp_architecture = "${var.icp_architecture}"
         icp_edition = "${var.icp_edition}"
         icp_download_location = "${var.icp_download_location}"
-	icp_disabled_services = "${join(", ",formatlist("\"%s\"",var.icp_disabled_services))}"
+        icp_disabled_services = "${join(", ",formatlist("\"%s\"",var.icp_disabled_services))}"
         install_user_name = "${var.icp_install_user}"
         install_user_password = "${var.icp_install_user_password}"
+        docker_download_location = "${var.docker_download_location}"
     }
 }

--- a/terraform/openstack/outputs.tf
+++ b/terraform/openstack/outputs.tf
@@ -16,3 +16,7 @@
 output "icp-master-vm-ip" {
     value = "${openstack_compute_instance_v2.icp-master-vm.network.0.fixed_ip_v4}"
 }
+
+output "icp-worker-vm-ips" {
+   value = "${openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4}"
+}

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -85,7 +85,7 @@ variable "icp_edition" {
 
 variable "icp_version" {
     description = "ICP version number"
-    default = "2.1.0"
+    default = "2.1.0.3"
 }
 
 variable "icp_architecture" {

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -110,3 +110,8 @@ variable "instance_prefix" {
     description = "Prefix to use in instance names"
     default = "icp"
 }
+
+variable "docker_download_location" {
+    description = "HTTP wget location for ICP provided Docker package"
+    default = ""
+}


### PR DESCRIPTION
Support for ICP 2.1.0.3 in the terraform/openstack module. 
Added logic to get proper icp docker image name
Added install of socat