### PR TITLE
Fixes to ICP version check for 3.1.0 and earlier versions

### DIFF
--- a/terraform/openstack/bootstrap_icp_master.sh
+++ b/terraform/openstack/bootstrap_icp_master.sh
@@ -26,19 +26,21 @@ do
 done
 
 # Determine the IBM Cloud Private embedded Docker image name
-if [ "$${iver[0]}" -ge "2" ] && [ "$${iver[1]}" -ge "1" ] &&
-    [ "$${iver[2]}" -ge "0" ] && [ "$${iver[3]}" -ge "3" ]; then
-    # ICP 2.1.0.3 or later
-    ICP_DOCKER_IMAGE="ibmcom/icp-inception:${icp_version}"
-elif [ "${icp_architecture}" == "ppc64le" ]; then
-    # ICP 2.1.0.2 or earlier ppc64le
-    ICP_DOCKER_IMAGE="ibmcom/icp-inception-ppc64le:${icp_version}"
-else
-    # ICP 2.1.0.2 or earlier x86
-    ICP_DOCKER_IMAGE="ibmcom/icp_inception:${icp_version}"
+ARCH_POSTFIX=""
+ICP_DOCKER_IMAGE="ibmcom/icp-inception"
+# For IBM Power, append ppc64le for ICP versions 2.1.0.2 and earlier
+if [ "${icp_architecture}" == "ppc64le" ] &&  [ "$${iver[0]}" -le "2" ] &&
+    [ "$${iver[1]}" -le "1" ] && [ "$${iver[2]}" -le "0" ] && [ "$${iver[3]}" -le "2" ]; then
+    ARCH_POSTFIX="-ppc64le"
 fi
+# For ICP ee, versions 3.x and beyond requires ARCH, for 2.1.0.3 ARCH is not needed
 if [ "${icp_edition}" == "ee" ]; then
-    ICP_DOCKER_IMAGE="$ICP_DOCKER_IMAGE-ee"
+    if [ "$${iver[0]}" -ge "3" ]; then
+        ARCH_POSTFIX="-"${icp_architecture}
+    fi
+    ICP_DOCKER_IMAGE="$ICP_DOCKER_IMAGE$ARCH_POSTFIX:${icp_version}-ee"
+else
+    ICP_DOCKER_IMAGE="$ICP_DOCKER_IMAGE$ARCH_POSTFIX:${icp_version}"
 fi
 
 # Root directory of ICP installation


### PR DESCRIPTION
The code checks the following conditions:
1. ICP 2.1.0.2 and earlier versions have arch appended to to the docker image only for ppc64le
2. ICP 2.1.0.3 do not have any arch mentioned in the image names
3. ICP 3.1.0 and beyond require arch mentioned in the images for ppc64le and amd64 arch types for ee while ce doesn't.