### PR TITLE
add remove workers

### DIFF
--- a/terraform/openstack/icp_worker_scaler.sh
+++ b/terraform/openstack/icp_worker_scaler.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright IBM Corp. 2017.
+#
+################################################################
+
+# Root directory of ICP installation
+ICP_ROOT_DIR="/opt/ibm-cloud-private-${2}"
+IPS=${3}
+
+if [[ ${1} == a* ]]; then
+    ICP_DOCKER_IMAGE=`sudo /usr/bin/docker ps -a | /bin/grep -i 'inception' | head -1 | /usr/bin/awk '{print $2}'`
+    cd "$ICP_ROOT_DIR/cluster"
+    sudo /usr/bin/docker run -e LICENSE=accept --net=host \
+        -v "$(pwd)":/installer/cluster \
+        $ICP_DOCKER_IMAGE worker -l $IPS | \
+        sudo /usr/bin/tee -a add_remove_worker.log
+elif [[ ${1} == r* ]]; then
+    ICP_DOCKER_IMAGE=`sudo /usr/bin/docker ps -a | /bin/grep -i 'inception' | head -1 | /usr/bin/awk '{print $2}'`
+    cd "$ICP_ROOT_DIR/cluster"
+    sudo /usr/bin/docker run -e LICENSE=accept --net=host \
+        -v "$(pwd)":/installer/cluster \
+        $ICP_DOCKER_IMAGE uninstall -l $IPS | \
+        sudo /usr/bin/tee -a add_remove_worker.log
+else
+   echo "None of the condition met"
+fi
+exit 0

--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -43,6 +43,25 @@ resource "openstack_compute_instance_v2" "icp-worker-vm" {
     }
 
     user_data = "${data.template_file.bootstrap_worker.rendered}"
+
+    provisioner "local-exec" {
+        command = "if ping -c 1 -W 1 $MASTER_IP; then ssh -o 'StrictHostKeyChecking no' -i $KEY_FILE USER@$MASTER_IP 'if [[ -f /tmp/icp_worker_scaler.sh ]]; then chmod a+x /tmp/icp_worker_scaler.sh; /tmp/icp_worker_scaler.sh a ${var.icp_edition} ${self.network.0.fixed_ip_v4}; fi'; fi"
+        environment {
+            MASTER_IP = "${openstack_compute_instance_v2.icp-master-vm.network.0.fixed_ip_v4}"
+            USER = "${var.icp_install_user}"
+            KEY_FILE = "${var.openstack_ssh_key_file}"
+        }
+    }
+
+    provisioner "local-exec" {
+        when    = "destroy"
+        command = "ssh -o 'StrictHostKeyChecking no' -i $KEY_FILE $USER@$MASTER_IP 'if [[ -f /tmp/icp_worker_scaler.sh ]]; then chmod a+x /tmp/icp_worker_scaler.sh; /tmp/icp_worker_scaler.sh r ${var.icp_edition} ${self.network.0.fixed_ip_v4}; fi'"
+        environment {
+            MASTER_IP = "${openstack_compute_instance_v2.icp-master-vm.network.0.fixed_ip_v4}"
+            USER = "${var.icp_install_user}"
+            KEY_FILE = "${var.openstack_ssh_key_file}"
+        }
+    }
 }
 
 resource "openstack_compute_instance_v2" "icp-master-vm" {
@@ -50,16 +69,6 @@ resource "openstack_compute_instance_v2" "icp-master-vm" {
     image_id  = "${var.openstack_image_id}"
     flavor_id = "${var.openstack_flavor_id_master_node}"
     key_pair  = "${openstack_compute_keypair_v2.icp-key-pair.name}"
-
-    personality {
-        file    = "/root/id_rsa.terraform"
-        content = "${file("${var.openstack_ssh_key_file}")}"
-    }
-
-    personality {
-        file    = "/root/icp_worker_nodes.txt"
-        content = "${join("|", openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4)}"
-    }
 
     network {
         name = "${var.openstack_network_name}"
@@ -89,5 +98,34 @@ data "template_file" "bootstrap_worker" {
 
     vars {
         docker_download_location = "${var.docker_download_location}"
+    }
+}
+
+resource "null_resource" "icp-worker-scaler" {
+    triggers {
+        workers = "${join("|", openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4)}"
+    }
+
+    connection {
+        type            = "ssh"
+        user            = "${var.icp_install_user}"
+        host            = "${openstack_compute_instance_v2.icp-master-vm.*.network.0.fixed_ip_v4}"
+        private_key     = "${file(var.openstack_ssh_key_file)}"
+        timeout         = "15m"
+    }
+
+    provisioner "file" {
+        source      = "${path.module}/icp_worker_scaler.sh"
+        destination = "/tmp/icp_worker_scaler.sh"
+    }
+
+    provisioner "file" {
+        content     = "${join("|", openstack_compute_instance_v2.icp-worker-vm.*.network.0.fixed_ip_v4)}"
+        destination = "/tmp/icp_worker_nodes.txt"
+    }
+
+    provisioner "file" {
+        content     = "${file("${var.openstack_ssh_key_file}")}"
+        destination = "/tmp/id_rsa.terraform"
     }
 }


### PR DESCRIPTION
First time configuration:
1. Master will start to boot first and starts the install steps,
2. Workers will boot and prepare itself with IP now assigned.
3. Provisioner will inject files required for install steps (including the script for add/remove workers) in master node.

Add/Remove workers (by changing icp_num_workers):
1. Worker resource will be added or deleted by Terraform.
2. Local-exec Provisioner in worker resource will remote login to master from the terminal during create and destroy.
3. Add/Remove script is called with worker information which add/delete worker from the cluster.

Things to note with this procedure:
1. Remote call is made to master for each worker IP.
2. Console output of adding/removing a worker is shown in Terraform output.
3. Use of provsioners instead of personality