### PR TITLE
Updated to use bento/ubuntu-16.04 v201808.24.0

### DIFF
--- a/Cachefile
+++ b/Cachefile
@@ -236,7 +236,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.define "icp_cache" do |icp_cache|
     icp_cache.vm.box = "bento/ubuntu-16.04"
-    icp_cache.vm.box_version = "201708.22.0"
+    icp_cache.vm.box_version = "201808.24.0"
     icp_cache.vm.hostname = "cache.icp"
     icp_cache.vm.box_check_update = false
     icp_cache.vm.network "private_network", ip: "#{base_segment}.99", adapter_ip: "#{base_segment}.1", netmask: "255.255.255.0", auto_config: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ cpus = '6'
 
 # should be sufficent on laptops with 16GiB of RAM (but you won't want to run any apps
 # while this vm is running)
-memory = '6144'
+memory = '8192'
 
 # Update version to pull a specific version i.e. version = '2.1.0-beta-1'
 version = "3.1.0"
@@ -21,7 +21,7 @@ version = "3.1.0"
 # on some systems this network segment may overlap another network already on your
 # system. In those cases you will need to change this value to another value
 # i.e. 192.168.56 or 192.168.16 etc...
-base_segment = '192.168.27'
+base_segment = '192.168.16'
 
 # use apt-cacher-ng & docker registry cache servers
 # see instructions in the `README.md` under #Advanced Cache Setup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1183,8 +1183,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.define "icp" do |icp|
     icp.vm.box = "bento/ubuntu-16.04"
-    icp.vm.box_version = "201806.08.0"
-    # icp.vm.box_version = "201710.25.0"
+    icp.vm.box_version = "201808.24.0"
+    # icp.vm.box_version = "201806.08.0"
     icp.vm.hostname = "master.icp"
     icp.vm.box_check_update = true
     icp.vm.network "private_network", ip: "#{base_segment}.100", adapter_ip: "#{base_segment}.1", netmask: "255.255.255.0", auto_config: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ cpus = '6'
 
 # should be sufficent on laptops with 16GiB of RAM (but you won't want to run any apps
 # while this vm is running)
-memory = '8192'
+memory = '6144'
 
 # Update version to pull a specific version i.e. version = '2.1.0-beta-1'
 version = "3.1.0"
@@ -21,7 +21,7 @@ version = "3.1.0"
 # on some systems this network segment may overlap another network already on your
 # system. In those cases you will need to change this value to another value
 # i.e. 192.168.56 or 192.168.16 etc...
-base_segment = '192.168.16'
+base_segment = '192.168.27'
 
 # use apt-cacher-ng & docker registry cache servers
 # see instructions in the `README.md` under #Advanced Cache Setup


### PR DESCRIPTION
Updated to use bento/ubuntu-16.04 v201808.24.0.
Still have to try with ubuntu-18.04, but if we stick 16.04, a new version of the VM image has been released.