### PR TITLE
Force confold etc for apt-get upgrade

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -287,7 +287,7 @@ HRNGDEVICE=/dev/urandom
 EOF
 sudo /etc/init.d/rng-tools restart
 sudo apt-get update --yes --quiet
-sudo apt-get upgrade --yes --quiet
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt autoremove --yes --quiet
 SCRIPT
 


### PR DESCRIPTION
grub update (during `apt-get upgrade`) was trying to go interactive during `vagrant up` because of the modified grub config from an earlier step. 
change upgrade command to set options to use old config, and not go interactive.