### PR TITLE
OpenStack deployment network interface name change

### DIFF
--- a/terraform/openstack/bootstrap_icp_worker.sh
+++ b/terraform/openstack/bootstrap_icp_worker.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # Ensure the hostname is resolvable
-IP=`/sbin/ip -4 -o addr show dev eth0 | awk '{split($4,a,"/");print a[1]}'`
+IP=$(/sbin/ip -4 addr show | awk '/state UP/ {getline; split($2,ip,"/"); print ip[1]}')
 /bin/echo "$IP $(hostname)" >> /etc/hosts
 
 exit 0

--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -45,7 +45,7 @@ resource "openstack_compute_instance_v2" "icp-worker-vm" {
     user_data = "${data.template_file.bootstrap_worker.rendered}"
 
     provisioner "local-exec" {
-        command = "if ping -c 1 -W 1 $MASTER_IP; then ssh -o 'StrictHostKeyChecking no' -i $KEY_FILE USER@$MASTER_IP 'if [[ -f /tmp/icp_worker_scaler.sh ]]; then chmod a+x /tmp/icp_worker_scaler.sh; /tmp/icp_worker_scaler.sh a ${var.icp_edition} ${self.network.0.fixed_ip_v4}; fi'; fi"
+        command = "if ping -c 1 -W 1 $MASTER_IP; then ssh -o 'StrictHostKeyChecking no' -i $KEY_FILE $USER@$MASTER_IP 'if [[ -f /tmp/icp_worker_scaler.sh ]]; then chmod a+x /tmp/icp_worker_scaler.sh; /tmp/icp_worker_scaler.sh a ${var.icp_edition} ${self.network.0.fixed_ip_v4}; fi'; fi"
         environment {
             MASTER_IP = "${openstack_compute_instance_v2.icp-master-vm.network.0.fixed_ip_v4}"
             USER = "${var.icp_install_user}"


### PR DESCRIPTION
Deployment on OpenStack fails because eth0 no longer present on newer distributions