### PR TITLE
Added parameter on build to avoid apk to hang

### DIFF
--- a/playbooks/prepare_sl_vms.yml
+++ b/playbooks/prepare_sl_vms.yml
@@ -166,7 +166,7 @@
         mode: 0755
 
     - name: Build installer image
-      command: docker build -t icp-on-sl /root/cluster
+      command: docker build --network host -t icp-on-sl /root/cluster
 
     - name: Run the following command to deploy IBM Cloud Private
       debug:


### PR DESCRIPTION
Made this small change on the playbook to include `--network host` parameter on docker build command to avoid apk to hang when trying to fetch Alpine linux image, as described on [docker-alpine issue 307](https://github.com/gliderlabs/docker-alpine/issues/307#issuecomment-357238983).