### PR TITLE
Check if resolvconf exists before trying to disable it

### DIFF
--- a/playbooks/prepare_sl_vms.yml
+++ b/playbooks/prepare_sl_vms.yml
@@ -53,7 +53,9 @@
       when: ansible_os_family == 'Debian'
 
     - name: disable resolvconf updates
-      command: resolvconf --disable-updates
+      command: /usr/bin/dpkg -l resolvconf &>dev/null &&\
+               resolvconf --disable-updates ||\
+               echo "resolvconf not currently installed."
       when: ansible_os_family == 'Debian'
 
     - name: add alternative dnsmasq resolv.conf


### PR DESCRIPTION
Added an additional step to confirm if resolvconf package is installed before trying to disable it to avoid the playbook to abort, as reported on issue [160](https://github.com/IBM/deploy-ibm-cloud-private/issues/160)