### PR TITLE
Proposing Ansible doc updates, and change DockerFile image version

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/icp-inception:2.1.0
+FROM ibmcom/icp-inception:latest
 
 RUN apk add --update python python-dev py-pip && \
     pip install softlayer

--- a/docs/deploy-softlayer-ansible.md
+++ b/docs/deploy-softlayer-ansible.md
@@ -1,5 +1,26 @@
 ## Deploy IBM Cloud Private beta on IBM Cloud (softlayer) with Ansible
 
+### Before you start...
+
+The following Ansible playbooks will be used for deploying your VM's on SoftLayer:
+
+|                       Playbook                        |                                                     Description                                                     |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [create_sl_vms.yml](../playbooks/create_sl_vms.yml)   | Create the VM's on SoftLayer according to the specifications found on [cluster/config.yaml](../cluster/config.yaml) |
+| [prepare_sl_vms.yml](../playbooks/prepare_sl_vms.yml) | Install all operating system packages required to for the ICP install.                                              |
+
+To customize the hardware definitions of the VM's you'll need to update your local copy of the provisioning playbooks, for instance if an additional disk or more CPU is required.
+
+Please notice that Primary disk sizes should go from 25 GB to 100 GB, if more space is required an additional disk should be created, its also important to notice that disk sizes must have the same size as defined at the default templates provided by the SoftLayer catalog or else your provisioning will fail. Check the documentation below for reference on default sizes available.
+ 
+ - [IBM Block Storage: Provisioning Considerations](https://console.bluemix.net/docs/infrastructure/BlockStorage/index.html#provisioning-with-performance)
+
+For a complete reference on the available arguments, check the following links:
+
+- [IBM Cloud Infrastructure (SoftLayer) API docs](http://sldn.softlayer.com/reference/services/SoftLayer_Virtual_Guest)
+- [IBM Cloud Provider (Argument Reference)](https://ibm-cloud.github.io/tf-ibm-docs/v0.11.1/r/compute_vm_instance.html)
+
+
 ### Prepare your local machine:
 
 The first thing you need to do is to clone this repo down and set up to use softlayer cli and ansible:


### PR DESCRIPTION
Proposing an update to the DockerFile image version from 2.1.0 to the `latest` tag instead (3.1.1 is the current latest version)

And also proposing a "Before you start" section at `deploy-softlayer-ansible.md` with the following content:

- Inform users on how to customize hardware specifications
- Inform users on restrictions related to increasing size of disks without causing the deployment to fail
- Add reference links for storage provisioning considerations and SoftLayer API argument reference docs.