### PR TITLE
Allow SMT levels to be set for the master node

### DIFF
--- a/terraform/openstack/bootstrap_icp_master.sh
+++ b/terraform/openstack/bootstrap_icp_master.sh
@@ -15,6 +15,24 @@
 #
 ################################################################
 
+#Allow SMT levels to be set for the master node
+if [ "${icp_architecture}" == "ppc64le" ] && [ ! -z "${smt_value_master}" ] && [ -f /usr/sbin/ppc64_cpu ]; then
+    /usr/sbin/ppc64_cpu --smt=${smt_value_master}
+    cat >> /etc/systemd/system/smt.service <<EOL
+[Unit]
+Description=Set SMT
+After=syslog.target
+[Service]
+Type=simple
+ExecStart=/usr/sbin/ppc64_cpu --smt=${smt_value_master}
+TimeoutSec=300
+[Install]
+WantedBy=multi-user.target
+EOL
+    /bin/systemctl daemon-reload
+    /bin/systemctl enable smt.service
+fi
+
 # Determine icp version
 IFS='.' read -r -a iver <<< ${icp_version}
 # fill in any empty digits (some only had 3)

--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -101,6 +101,7 @@ data "template_file" "bootstrap_init" {
         cam_download_location = "${var.cam_download_location}"
         cam_download_user = "${var.cam_download_user}"
         cam_download_password = "${var.cam_download_password}"
+        smt_value_master = "${var.smt_value_master}"
     }
 }
 

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -168,3 +168,9 @@ variable "cam_download_user" {
 variable "cam_download_password" {
     default = ""
 }
+
+#Variable required to set the desired SMT level for master node
+variable "smt_value_master" {
+    description = "Number of threads per core. Value can be any of: on, off, 1, 2, 4, 8"
+    default = ""
+}


### PR DESCRIPTION
As IBM Power Systems support various processor SMT levels, we should allow the user to adjust the level if they'd like.
User should be able to specify separate SMT levels for the master node. The SMT level can be changed in the bootstrap scripts (early on, prior to any installation being performed) via:
ppc64_cpu --smt=X
...where X is the desired SMT level (it can be any of: on, off, 1, 2, 4, 8).