### PR TITLE
New Terraform template for PowerVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Instructions:
 * [Deploy in Softlayer VMs using Ansible](docs/deploy-softlayer-ansible.md)
 * [Deploy in Softlayer VMs using Terraform](docs/deploy-softlayer-terraform.md)
 * [Deploy in OpenStack using Terraform](docs/deploy-openstack-terraform.md)
+* [Deploy in PowerVC using Terraform](docs/deploy-powervc-terraform.md)
 * [Optional - add NFS dynamic provsioner to your cluster](docs/deploy-nfs-provisioner.md)
 
 

--- a/docs/deploy-powervc-terraform.md
+++ b/docs/deploy-powervc-terraform.md
@@ -1,0 +1,121 @@
+Summary
+=======
+This Terraform module will perform a simple IBM Cloud Private (ICP) deployment. By default, it will install the Community Edition, but you can also configure it to install the Enterprise Edition as well. It is currently setup to deploy an ICP master node (also serves as the boot, proxy, and management node) and a user-configurable number of ICP worker nodes. This module serves as a simple way to provision an ICP cluster within your infrastructure.
+
+
+Pre-requisites
+------------
+* Get access to an OpenStack (or PowerVC) server instance.
+* If the default SSH user is not the root user, the default user must have password-less sudo access.
+* Install [Terraform](https://www.terraform.io/downloads.html) on your workstation.
+* Refer to ICP documentation for installation pre-requisites. https://www.ibm.com/support/knowledgecenter/en/SSBS6K/product_welcome_cloud_private.html
+
+Supported OS versions
+------------
+This Terraform deployment supports the following OS images on different platforms. Check ICP documentation for supported system configurations.
+    * Ubuntu 18.04 LTS and 16.04 LTS
+    * Red Hat Enterprise Linux (RHEL) 7.4, 7.5, and 7.6
+    * SUSE Linux Enterprise Server (SLES) 12 SP3
+    
+Additional image considerations
+------------
+Ensure that the base image used for deployment have necessary repositories configured to install docker and other packages, or have all the below packages pre-installed.
+* docker-ce (docker for SLES) -  ICP Enterprise Edition users should use the ICP-provided platform specific docker tar ball and the docker_download_location variable in variables.tf to specify the download url.
+* moreutils
+* container-selinux
+* socat
+
+Instructions
+------------
+1. Login to your Terraform workstation.
+2. Clone this repository. (git clone git@github.com:IBM/deploy-ibm-cloud-private.git)
+3. Generate an SSH key pair. This will be referenced in Inputs below. (ssh-keygen -t rsa)
+4. Edit the contents of variables.tf to align with your OpenStack (or PowerVC) deployment. (see Inputs section below)
+5. Run terraform init to initialize and download the terraform modules needed for deployment.
+6. Run [terraform apply] to start the ICP deployment to the OpenStack server.
+7. Wait about 30-40 minutes, you should be able to access your ICP cluster at https://<ICP_MASTER_IP_ADDRESS>:8443
+
+See [Accessing IBM Cloud](https://github.com/yussufsh/deploy-ibm-cloud-private/blob/hdcw/README.md#accessing-ibm-cloud-private) Private for next steps.
+
+Inputs
+------------
+**Configure the OpenStack Provider**
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|openstack_user_name|my_user_name|string|The user name used to connect to OpenStack|
+|openstack_password|my_password|string|The password for the user|
+|openstack_project_name|ibm-default|string|The name of the project (a.k.a. tenant) used|
+|openstack_domain_name|Default|string|The domain to be used|
+|openstack_auth_url|https://<HOSTNAME>:5000/v3/|string|The endpoint URL used to connect to OpenStack|
+
+**Configure the Instance details**
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|instance_prefix|icp|string|Prefix to use in instance names|
+|openstack_image_id|my_image_id|string|The ID of the image to be used for deploy operations|
+|openstack_flavor_id_master_node|my_flavor_id|string|The ID of the flavor to be used for ICP master node deploy operations|
+|openstack_flavor_id_worker_node|my_flavor_id|string|The ID of the flavor to be used for ICP worker node deploy operations|
+|openstack_network_name|my_network_name|string|The name of the network to be used for deploy operations|
+|openstack_ssh_key_file|<path to the private SSH key file>|string|The path to the private SSH key file. Appending '.pub' indicates the public key filename|
+
+
+**Configure ICP details**
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|icp_install_user|ubuntu|string|The user with sudo access across nodes (users section of cloud-init)|
+|icp_install_user_password||string|Password for sudo access (leave empty if using passwordless sudo access)|
+|icp_num_workers|1|string|The number of ICP worker nodes to provision|
+|icp_version|3.1.2|string|ICP version number|
+|icp_architecture|ppc64le|string|x86 or ppc64le|
+|icp_download_location||string|HTTP wget location for ICP Enterprise Edition - ignored for community edition|
+|icp_default_admin_password|S3cure-icp-admin-passw0rd-default|string|Password to use for default admin user|
+|icp_management_services|{<br/>"istio" = "disabled"<br/> "metering" = "enabled"<br/>}|map|Map of management services to enable/disable in icp config.yaml|
+|docker_download_location||string|HTTP wget location for ICP provided Docker package|
+
+**Configure MCM details**
+This is an optional component to install on top of ICP.
+Will enable if *mcm_download_location* is provided in input variables.
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|mcm_download_location||string|HTTP wget location for MCM tarball|
+|mcm_download_user|-|string|Optional username if authentication required for MCM tarball|
+|mcm_download_password|-|string|Optional password if authentication required for MCM tarball|
+
+**Configure CAM common details**
+This is an optional component to install on top of ICP.
+Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_download_location* is provided for *Offline Installation* in input variables. *cam_docker_user* should be empty string for *Offline Installation*.
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|cam_version|3.1.0|string|Manditory version of Cloud Automation Manager to install|
+|cam_product_id||string|Product Id text for Cloud Automation Manager (EE)|
+|cam_docker_user||string|Docker Store user name, needs subscription to CAM (see documentation)|
+|cam_docker_password||string|Docker Store API key OR password|
+|cam_download_location||string|HTTP wget location for CAM tarball|
+|cam_download_user|-|string|Optional username if authentication required for CAM tarball|
+|cam_download_password|-|string|Optional password if authentication required for CAM tarball|
+
+**Configure SMT level for master node**
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|smt_value_master||string|Number of threads per core. Value can be any of: on, off, 1, 2, 4, 8|
+
+Additional Information
+------------
+* There are multiple ways to pass input variables to Terraform module. See [docs](https://www.terraform.io/docs/configuration/variables.html#assigning-values-to-root-module-variables) for more information.
+* You can re-install MCM from the cluster using below commands.
+<br/>`terraform destroy -target=null_resource.mcm_install`
+<br/>`terraform apply`
+* You can re-install CAM from the cluster using below commands.
+<br/>`terraform destroy -target=null_resource.cam_install`
+<br/>`terraform apply`
+
+
+Authors
+------------
+Yussuf Shaikh yussuf@us.ibm.com

--- a/terraform/modules/cam/main.tf
+++ b/terraform/modules/cam/main.tf
@@ -1,0 +1,77 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+
+resource "null_resource" "cam_install_wait" {
+    count   = "${var.cam_docker_user != "" || var.cam_download_location != "" ? 1 : 0}"
+    provisioner "local-exec" {
+        command = "echo ICP install complete status is ${var.icp_status}"
+    }
+}
+
+
+resource "null_resource" "cam_install" {
+    depends_on = ["null_resource.cam_install_wait"]
+    count   = "${var.cam_docker_user != "" || var.cam_download_location != "" ? 1 : 0}"
+
+    connection {
+        host          = "${var.icp_master}"
+        user          = "${var.ssh_user}"
+        private_key   = "${base64decode(var.ssh_key_base64)}"
+        agent         = "${var.ssh_agent}"
+        bastion_host  = "${var.bastion_host}"
+    }
+
+    provisioner "remote-exec" {
+        when = "destroy"
+        inline = [
+          "echo destroy"
+        ]
+    }
+    provisioner "file" {
+        source = "${path.module}/scripts/cam_install.sh"
+        destination = "/tmp/cam_install.sh"
+    }
+
+    provisioner "file" {
+        when = "destroy"
+        source = "${path.module}/scripts/cam_cleanup.sh"
+        destination = "/tmp/cam_cleanup.sh"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+          "chmod 755 /tmp/cam_install.sh",
+          "if [ ! -z '${var.cam_docker_user}' ]; then bash -c '/tmp/cam_install.sh ONLINE ${var.icp_master} ${var.cam_version} ${var.cluster_name} ${var.icp_admin_user}  ${var.icp_admin_user_password} ${var.cam_docker_user} ${var.cam_docker_password} ${var.cam_docker_secret} ${var.cam_product_id}'; fi",
+          "if [ ! -z ${var.cam_download_location} ] && [ -z ${var.cam_docker_user} ]; then bash -c '/tmp/cam_install.sh OFFLINE ${var.icp_master} ${var.cam_version} ${var.cluster_name} ${var.icp_admin_user} ${var.icp_admin_user_password} ${var.cam_download_location} ${var.cam_download_user} ${var.cam_download_password} ${var.cam_product_id}'; fi"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        when = "destroy"
+        inline = [
+          "chmod 755 /tmp/cam_cleanup.sh",
+          "bash -c '/tmp/cam_cleanup.sh ${var.icp_master} ${var.icp_admin_user} ${var.icp_admin_user_password} ${var.cam_docker_secret}'"
+        ]
+    }
+}

--- a/terraform/modules/cam/scripts/cam_cleanup.sh
+++ b/terraform/modules/cam/scripts/cam_cleanup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Set HOME env var, populate systemArch, helm init and cloudctl login
+function clean_cam {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 \
+        --skip-ssl-validation -u ${icp_admin_user} -p ${icp_admin_user_password} -n services
+
+    helm del --purge cam --timeout 1800 --tls
+    kubectl delete pod --grace-period=0 --force --namespace services -l release=cam
+
+    kubectl delete secret ${cam_docker_secret} -n services
+}
+
+# Install and configure exportfs; Create Persistent Volumes
+function delete_persistent_volumes {
+    pvs=( cam-mongo cam-logs cam-terraform cam-bpd-appdata )
+    dir_names=( db logs terraform BPD_appdata )
+    for ((i = 0; i < ${#pvs[@]}; ++i)); do
+        item=${pvs[${i}]}
+        kubectl delete pvc ${item}-pv
+        kubectl delete pv ${item}-pv
+    done
+    sudo sed -i '/\/cam_export*/d' /etc/exports
+}
+
+# Delete a deployment ServiceID policies and API Key
+function delete_deployment_key {
+    export serviceIDName='service-deploy'
+    export serviceApiKeyName='service-deploy-api-key'
+    cloudctl iam service-id-delete ${serviceIDName} -f
+}
+
+
+HUB_CLUSTER_IP=$1
+icp_admin_user=$2
+icp_admin_user_password=$3
+cam_docker_secret=$4
+
+/bin/echo
+/bin/echo "Cleaning CAM.."
+
+clean_cam
+delete_deployment_key
+delete_persistent_volumes
+/bin/echo "CAM cleaning completed"
+

--- a/terraform/modules/cam/scripts/cam_install.sh
+++ b/terraform/modules/cam/scripts/cam_install.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Set HOME env var, populate ARCH, helm init and cloudctl login
+function init_cam {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    systemArch=$(arch)
+    if [ "${systemArch}" == "x86_64" ]; then systemArch='amd64'; fi
+
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 \
+        --skip-ssl-validation -u ${icp_admin_user} -p ${icp_admin_user_password} -n services
+    docker login ${cluster_name}.icp:8500 -u ${icp_admin_user} -p ${icp_admin_user_password}
+}
+
+# Create Docker Store secret
+function create_docker_secret {
+    kubectl delete secret ${cam_docker_secret} -n services &> /dev/null
+    kubectl create secret docker-registry -n services ${cam_docker_secret} \
+        --docker-username=${docker_user} --docker-password=${docker_password}
+    kubectl patch serviceaccount default -n services -p \
+        '{"imagePullSecrets": [{"name": "${cam_docker_secret}"}]}'
+}
+
+# Download and Load PPA archive
+function load_ppa_archive {
+    if [[ ! -f /tmp/cam.tar.gz ]]; then
+        if [[ "${user}" == "-" ]]; then user=""; fi
+        if [[ "${password}" == "-" ]]; then password=""; fi
+        wget -nv --continue ${user:+--user} ${user} ${password:+--password} ${password} \
+            -O /tmp/cam.tar.gz "${location}"
+        if [[ $? -gt 0 ]]; then
+            /bin/echo "Error downloading ${location}" >&2
+            exit 1
+        fi
+     fi
+    cloudctl catalog load-archive -a /tmp/cam.tar.gz
+    wget https://mycluster.icp:8443/helm-repo/requiredAssets/ibm-cam-${VERSION}.tgz --no-check-certificate
+}
+
+# Add Helm Repos
+function add_ibm_chart_repos {
+    helm repo add ibm-stable \
+        https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+    helm repo add local-charts https://${HUB_CLUSTER_IP}:8443/helm-repo/charts \
+        --ca-file ~/.helm/ca.pem --cert-file ~/.helm/cert.pem \
+        --key-file ~/.helm/key.pem
+    helm fetch ibm-stable/ibm-cam --version ${VERSION}
+    helm repo update
+}
+
+# Install and configure exportfs; Create Persistent Volumes
+function create_persistent_volumes {
+    if [ -f /etc/redhat-release ]; then
+        sudo yum -y install nfs-utils
+    elif [ -f /etc/SuSE-release ]; then
+        sudo zypper -n install nfs-kernel-server
+    else
+        sudo apt-get -y install nfs-kernel-server
+    fi
+    sudo mkdir -p /cam_export/
+    sudo sed -i '/\/cam_export*/d' /etc/exports
+    echo "/cam_export *(rw,insecure,no_subtree_check,async,no_root_squash)" | sudo tee -a /etc/exports &> /dev/null
+    pvs=( cam-mongo cam-logs cam-terraform cam-bpd-appdata )
+    sizes=( 15 10 15 20 )
+    dir_names=( db logs terraform BPD_appdata )
+    for ((i = 0; i < ${#pvs[@]}; ++i)); do
+        item=${pvs[${i}]}
+        export_dir_name=/cam_export/CAM_${dir_names[${i}]}
+        sudo tee /tmp/${item}-pv.yaml &> /dev/null <<EOL
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: ${item}-pv
+  labels:
+    type: ${item}
+spec:
+  capacity:
+    storage: ${sizes[${i}]}Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: mycluster.icp
+    path: ${export_dir_name}
+EOL
+        sudo chmod -R 755 /tmp/${item}-pv.yaml
+        kubectl create -f /tmp/${item}-pv.yaml
+        sudo mkdir -p ${export_dir_name}
+        sudo chmod -R 755 ${export_dir_name}
+        echo "${export_dir_name} *(rw,nohide,insecure,no_subtree_check,async,no_root_squash)" | sudo tee -a /etc/exports &> /dev/null
+    done
+    sudo chmod -R 755 /cam_export
+    sudo exportfs -a
+}
+
+# Generate a deployment ServiceID API Key
+function generate_deployment_key {
+    export serviceIDName='service-deploy'
+    export serviceApiKeyName='service-deploy-api-key'
+    cloudctl iam service-id-delete ${serviceIDName} -f &> /dev/null
+    cloudctl iam service-id-create ${serviceIDName} \
+        -d 'Service ID for service-deploy'
+    cloudctl iam service-policy-create ${serviceIDName} \
+        -r Administrator,ClusterAdministrator --service-name 'idmgmt'
+    cloudctl iam service-policy-create ${serviceIDName} \
+        -r Administrator,ClusterAdministrator --service-name 'identity'
+    export deployApiKey=`cloudctl iam service-api-key-create \
+        ${serviceApiKeyName} ${serviceIDName} \
+        -d 'Api key for service-deploy' | grep 'API Key' | awk '{print $NF}'`
+}
+
+# Install Cloud Automation Manager
+function install_cam {
+    if [ -z ${product_id} ]; then
+        helm install ibm-cam-${VERSION}.tgz --name cam --namespace services --timeout 1800\
+            --set global.image.secretName=${cam_docker_secret} --set arch=${systemArch} \
+            --set global.iam.deployApiKey=${deployApiKey} --tls
+    else
+        helm install ibm-cam-${VERSION}.tgz --name cam --namespace services --timeout 1800\
+            --set global.image.secretName=${cam_docker_secret} --set arch=${systemArch} \
+            --set global.iam.deployApiKey=${deployApiKey} \
+            --set global.id.productID=${product_id} --tls
+    fi
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "CAM installation failed" >&2
+        rm -rf ibm-cam-${VERSION}.tgz
+        exit 1
+    fi
+    rm -rf ibm-cam-${VERSION}.tgz
+}
+
+
+/bin/echo "/tmp/cam_install.sh " $*
+METHOD=$1
+HUB_CLUSTER_IP=$2
+VERSION=$3
+cluster_name=$4
+icp_admin_user=$5
+icp_admin_user_password=$6
+
+
+/bin/echo
+/bin/echo "Installing CAM.."
+if [ $METHOD == "ONLINE" ]; then
+    docker_user=$7
+    docker_password=$8
+    cam_docker_secret=$9
+    product_id=$10
+    init_cam
+    create_docker_secret
+    add_ibm_chart_repos
+    create_persistent_volumes
+    generate_deployment_key
+    install_cam
+else
+    location=$7
+    user=$8
+    password=$9
+    product_id=$10
+    init_cam
+    load_ppa_archive
+    create_persistent_volumes
+    generate_deployment_key
+    install_cam
+fi
+/bin/echo "CAM installation completed"
+

--- a/terraform/modules/cam/variables.tf
+++ b/terraform/modules/cam/variables.tf
@@ -1,0 +1,67 @@
+variable "icp_status" {
+    default = ""
+}
+
+variable "icp_master" {
+    default = ""
+}
+
+variable "ssh_user" {
+    default = "root"
+}
+
+variable "ssh_key_base64" {
+    default = ""
+}
+
+variable "ssh_agent" {
+    default = "false"
+}
+
+variable "bastion_host" {
+    default = ""
+}
+
+variable "cam_version" {
+    default = ""
+}
+
+variable "cluster_name" {
+    default = ""
+}
+
+variable "icp_admin_user" {
+    default = ""
+}
+
+variable "icp_admin_user_password" {
+    default = ""
+}
+
+variable "cam_docker_user" {
+    default = ""
+}
+
+variable "cam_docker_password" {
+    default = ""
+}
+
+variable "cam_docker_secret" {
+    default = ""
+}
+
+variable "cam_download_location" {
+    default = ""
+}
+
+variable "cam_download_user" {
+    default = "-"
+}
+
+variable "cam_download_password" {
+    default = "-"
+}
+
+variable "cam_product_id" {
+    default = ""
+}

--- a/terraform/modules/mcm/main.tf
+++ b/terraform/modules/mcm/main.tf
@@ -1,0 +1,76 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+
+resource "null_resource" "mcm_install_wait" {
+    count   = "${var.mcm_download_location == "" ? 0 : 1}"
+    provisioner "local-exec" {
+        command = "echo ICP install complete status is ${var.icp_status}"
+    }
+}
+
+
+resource "null_resource" "mcm_install" {
+    count   = "${var.mcm_download_location == "" ? 0 : 1}"
+    depends_on = ["null_resource.mcm_install_wait"]
+
+    connection {
+        host          = "${var.icp_master}"
+        user          = "${var.ssh_user}"
+        private_key   = "${base64decode(var.ssh_key_base64)}"
+        agent         = "${var.ssh_agent}"
+        bastion_host  = "${var.bastion_host}"
+    }
+
+    provisioner "remote-exec" {
+        when = "destroy"
+        inline = [
+          "echo destroy"
+        ]
+    }
+    provisioner "file" {
+        source = "${path.module}/scripts/mcm_install.sh"
+        destination = "/tmp/mcm_install.sh"
+    }
+
+    provisioner "file" {
+        when = "destroy"
+        source = "${path.module}/scripts/mcm_cleanup.sh"
+        destination = "/tmp/mcm_cleanup.sh"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+          "chmod 755 /tmp/mcm_install.sh",
+          "bash -c '/tmp/mcm_install.sh ${var.icp_master} ${var.icp_version} ${var.cluster_name} ${var.icp_admin_user} ${var.icp_admin_user_password} ${var.mcm_secret} ${var.mcm_namespace} ${var.mcm_cluster_namespace} ${var.mcm_download_location} ${var.mcm_download_user} ${var.mcm_download_password}'"
+        ]
+    }
+
+    provisioner "remote-exec" {
+        when = "destroy"
+        inline = [
+          "chmod 755 /tmp/mcm_cleanup.sh",
+          "bash -c '/tmp/mcm_cleanup.sh ${var.icp_master} ${var.icp_admin_user} ${var.icp_admin_user_password} ${var.mcm_secret} ${var.mcm_namespace} ${var.mcm_cluster_namespace}'"
+        ]
+    }
+}

--- a/terraform/modules/mcm/scripts/mcm_cleanup.sh
+++ b/terraform/modules/mcm/scripts/mcm_cleanup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Set HOME env var, populate systemArch, helm init and cloudctl login
+function clean_mcm {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 \
+        --skip-ssl-validation -u ${icp_admin_user} -p ${icp_admin_user_password} -n kube-system
+
+    export MCM_HELM_RELEASE_NAME=mcm-release
+    helm del --purge ${MCM_HELM_RELEASE_NAME} --timeout 1800 --tls
+    kubectl delete pod --grace-period=0 --force --namespace kube-system -l release=${MCM_HELM_RELEASE_NAME}
+
+    export MCMK_HELM_RELEASE_NAME=mcmk-release
+    helm del --purge ${MCMK_HELM_RELEASE_NAME} --timeout 1800 --tls
+    kubectl delete pod --grace-period=0 --force --namespace kube-system -l release=${MCMK_HELM_RELEASE_NAME}
+
+    cloudctl catalog delete-chart --name ibm-mcm-prod
+    cloudctl catalog delete-chart --name ibm-mcmk-prod
+
+    kubectl delete secret ${helm_secret} -n kube-system
+    kubectl delete namespace ${mcm_namespace}
+    kubectl delete namespace ${mcm_cluster_namespace}
+}
+
+
+HUB_CLUSTER_IP=$1
+icp_admin_user=$2
+icp_admin_user_password=$3
+helm_secret=$4
+mcm_namespace=$5
+mcm_cluster_namespace=$6
+
+/bin/echo
+/bin/echo "Cleaning MCM.."
+
+clean_mcm
+/bin/echo "MCM cleaning completed"

--- a/terraform/modules/mcm/scripts/mcm_install.sh
+++ b/terraform/modules/mcm/scripts/mcm_install.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Set HOME env var, populate systemArch, helm init and cloudctl login
+function init_mcm {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    systemArch=$(arch)
+    if [ "${systemArch}" == "x86_64" ]; then systemArch='amd64'; fi
+    
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 \
+        --skip-ssl-validation -u ${icp_admin_user} -p ${icp_admin_user_password} -n kube-system
+    docker login ${cluster_name}.icp:8500 -u ${icp_admin_user} -p ${icp_admin_user_password}
+}
+
+# Download and Load PPA archive
+function load_ppa_archive {
+    if [[ ! -f /tmp/mcm.tgz ]]; then
+        if [[ "${user}" == "-" ]]; then user=""; fi
+        if [[ "${password}" == "-" ]]; then password=""; fi
+        wget -nv --continue ${user:+--user} ${user} ${password:+--password} ${password} \
+            -O /tmp/mcm.tgz "${location}"
+        if [[ $? -gt 0 ]]; then
+            /bin/echo "Error downloading ${location}" >&2
+            exit 1
+        fi
+    fi
+    cd /tmp/
+    tar -zxvf mcm.tgz
+    mcm_file="/tmp/mcm-${ICP_VERSION}/mcm"
+    if [ $ICP_VERSION == "3.1.1" ]; then
+        mcm_file="${mcm_file}-${ICP_VERSION}-${systemArch}.tgz"
+    else
+        mcm_file="${mcm_file}-ppa-${ICP_VERSION}.tgz"
+    fi
+    cd -
+
+    cloudctl catalog load-ppa-archive -a ${mcm_file} \
+        --registry ${cluster_name}.icp:8500/kube-system
+}
+
+# Create MCM namespace and Tiller secret
+function create_namespace_n_secret {
+    
+    if ! kubectl get secret ${mcm_secret} &> /dev/null; then
+        kubectl create secret tls ${mcm_secret} \
+            --cert ~/.helm/cert.pem --key ~/.helm/key.pem -n kube-system
+    else
+        echo "Secret ${mcm_secret_name} already exists"
+    fi
+    kubectl create namespace ${mcm_namespace}
+}
+
+# Add helm chart
+function add_ibm_chart_repos {
+
+    helm repo add local-charts https://${HUB_CLUSTER_IP}:8443/helm-repo/charts \
+        --ca-file ~/.helm/ca.pem --cert-file ~/.helm/cert.pem --key-file ~/.helm/key.pem
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "Error adding local-charts, installing from tarball" >&2
+        CHARTNAME=$mcm_file
+    else
+        CHARTNAME=local-charts/ibm-mcm-prod
+    fi
+    helm repo update
+}
+
+# Install MultiCloud Manager
+function install_mcm {
+    export MCM_HELM_RELEASE_NAME=mcm-release
+    helm upgrade --install ${MCM_HELM_RELEASE_NAME} \
+        --timeout 1800 --namespace kube-system \
+        --set compliance.mcmNamespace=${mcm_namespace} \
+        --set topology.enabled=true \
+        ${CHARTNAME} --tls \
+        --ca-file ~/.helm/ca.pem --cert-file ~/.helm/cert.pem --key-file ~/.helm/key.pem
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "MCM installation failed" >&2
+        exit 1
+    fi
+}
+
+# Install MCM Klusterlet
+function install_mcm_klusterlet {
+    export HUB_CLUSTER_URL=`kubectl config view -o \
+        jsonpath="{.clusters[?(@.name==\"${cluster_name}\")].cluster.server}"`
+    export HUB_CLUSTER_TOKEN=`kubectl config view -o \
+        jsonpath="{.users[?(@.name==\"${cluster_name}-user\")].user.token}"`
+    CHARTNAME=local-charts/ibm-mcmk-prod
+
+    export MCMK_HELM_RELEASE_NAME=mcmk-release
+    helm upgrade --install ${MCMK_HELM_RELEASE_NAME} \
+        --timeout 1800 --namespace kube-system \
+        --set klusterlet.enabled=true \
+        --set klusterlet.clusterName=${cluster_name} \
+        --set klusterlet.clusterNamespace=${mcm_cluster_namespace} \
+        --set klusterlet.tillersecret=${mcm_secret} \
+        --set klusterlet.apiserverConfig.server=${HUB_CLUSTER_URL} \
+        --set klusterlet.apiserverConfig.token=${HUB_CLUSTER_TOKEN} \
+        ${CHARTNAME} --tls \
+        --ca-file ~/.helm/ca.pem --cert-file ~/.helm/cert.pem --key-file ~/.helm/key.pem
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "MCM Klusterlet installation failed" >&2
+        exit 1
+    fi
+}
+
+# Install CLI
+function install_mcm_cli {
+    docker run -e LICENSE=accept -v /usr/local/bin:/data \
+        ${cluster_name}.icp:8500/kube-system/mcmctl:${ICP_VERSION} \
+        cp mcmctl-linux-${systemArch} /data/mcmctl
+}
+
+
+/bin/echo "/tmp/install_mcm.sh " $*
+
+HUB_CLUSTER_IP=$1
+ICP_VERSION=$2
+cluster_name=$3
+icp_admin_user=$4
+icp_admin_user_password=$5
+mcm_secret=$6
+mcm_namespace=$7
+mcm_cluster_namespace=$8
+
+/bin/echo
+/bin/echo "Installing MCM.."
+location=$9
+user=$10
+password=$11
+
+init_mcm
+load_ppa_archive
+create_namespace_n_secret
+add_ibm_chart_repos
+install_mcm
+install_mcm_klusterlet
+install_mcm_cli
+/bin/echo "MCM installation completed"

--- a/terraform/modules/mcm/variables.tf
+++ b/terraform/modules/mcm/variables.tf
@@ -1,0 +1,63 @@
+variable "icp_status" {
+    default = ""
+}
+
+variable "icp_master" {
+    default = ""
+}
+
+variable "ssh_user" {
+    default = "root"
+}
+
+variable "ssh_key_base64" {
+    default = ""
+}
+
+variable "ssh_agent" {
+    default = "false"
+}
+
+variable "bastion_host" {
+    default = ""
+}
+
+variable "icp_version" {
+    default = ""
+}
+
+variable "cluster_name" {
+    default = ""
+}
+
+variable "icp_admin_user" {
+    default = ""
+}
+
+variable "icp_admin_user_password" {
+    default = ""
+}
+
+variable "mcm_secret" {
+    default = ""
+}
+
+variable "mcm_namespace" {
+    default = ""
+}
+
+variable "mcm_cluster_namespace" {
+    default = ""
+}
+
+variable "mcm_download_location" {
+    default = ""
+}
+
+variable "mcm_download_user" {
+    default = "-"
+}
+
+variable "mcm_download_password" {
+    default = "-"
+}

--- a/terraform/powervc/deploy.tf
+++ b/terraform/powervc/deploy.tf
@@ -1,0 +1,113 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+################################################################
+## Generate local map
+################################################################
+locals {
+    depends_on = ["null_resource.wait-for-master"]
+    config = {
+        "default_admin_password"    = "${var.icp_default_admin_password}"
+        "ansible_user"              = "${var.icp_install_user}"
+        "ansible_become"            = "true"
+        "ansible_become_password"   = "${var.icp_install_user_password}"
+        "management_services"       = "${var.icp_management_services}"
+    }
+}
+
+################################################################
+## Call the ICP Deployment module
+################################################################
+module "icpprovision" {
+    source                  = "github.com/ibm-cloud-architecture/terraform-module-icp-deploy?ref=3.0.8"
+
+    icp-master              = ["${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"]
+    icp-worker              = ["${openstack_compute_instance_v2.icp_worker_vm.*.network.0.fixed_ip_v4}"]
+    icp-proxy               = ["${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"]
+
+    cluster_size            = "${openstack_compute_instance_v2.icp_master_vm.count + openstack_compute_instance_v2.icp_worker_vm.count}"
+
+    icp_configuration       = "${local.config}"
+
+    icp-inception           = "${var.icp_version}"
+    generate_key            = "false"
+    icp_priv_key            = "${file(var.openstack_ssh_key_file)}"
+    icp_pub_key             = "${file("${var.openstack_ssh_key_file}.pub")}"
+    ssh_user                = "${var.icp_install_user}"
+    ssh_key_base64          = "${base64encode(file(var.openstack_ssh_key_file))}"
+    ssh_agent               = "false"
+
+    # Docker is configured with local bootstrap files for all supported OS
+    #docker_package_location = "${var.docker_download_location}"
+    
+    image_location = "${var.icp_download_location}"
+
+    hooks = {
+        cluster-preconfig = ["echo 'DEBUG: cluster-preconfig'"]
+        cluster-postconfig = ["echo 'DEBUG: cluster-postconfig'"]
+        boot-preconfig = ["echo 'DEBUG: boot-preconfig'"]
+        preinstall = ["echo 'DEBUG: preinstall'"]
+        postinstall = ["echo 'DEBUG: postinstall'"]
+    }
+}
+
+module "mcm_install" {
+    source                  = "../modules/mcm"
+
+    icp_status              = "${module.icpprovision.install_complete}"
+    ssh_user                = "${var.icp_install_user}"
+    ssh_key_base64          = "${base64encode(file(var.openstack_ssh_key_file))}"
+    ssh_agent               = "false"
+    icp_master              = "${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"
+    icp_version             = "${var.icp_version}"
+    cluster_name            = "mycluster"
+    icp_admin_user          = "admin"
+    icp_admin_user_password = "${module.icpprovision.default_admin_password}"
+    mcm_secret              = "secret"
+    mcm_namespace           = "mcm"
+    mcm_cluster_namespace   = "cmcm"
+    mcm_download_location   = "${var.mcm_download_location}"
+    mcm_download_user       = "${var.mcm_download_user}"
+    mcm_download_password   = "${var.mcm_download_password}"
+}
+
+module "cam_install" {
+    source                  = "../modules/cam"
+
+    icp_status              = "${module.icpprovision.install_complete}"
+    ssh_user                = "${var.icp_install_user}"
+    ssh_key_base64          = "${base64encode(file(var.openstack_ssh_key_file))}"
+    ssh_agent               = "false"
+    icp_master              = "${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"
+    cluster_name            = "mycluster"
+    icp_admin_user          = "admin"
+    icp_admin_user_password = "${module.icpprovision.default_admin_password}"
+    cam_version             = "${var.cam_version}"
+    cam_docker_user         = "${var.cam_docker_user}"
+    cam_docker_password     = "${var.cam_docker_password}"
+    cam_docker_secret       = "camdockersecret"
+    cam_download_location   = "${var.cam_download_location}"
+    cam_download_user       = "${var.cam_download_user}"
+    cam_download_password   = "${var.cam_download_password}"
+    cam_product_id          = "${var.cam_product_id}"
+}

--- a/terraform/powervc/instances.tf
+++ b/terraform/powervc/instances.tf
@@ -1,0 +1,99 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+################################################################
+# Create Master Nodes
+################################################################
+resource "openstack_compute_instance_v2" "icp_master_vm" {
+    name      = "${var.instance_prefix}-master-${random_id.rand.hex}"
+    image_id  = "${var.openstack_image_id}"
+    flavor_id = "${var.openstack_flavor_id_master_node}"
+    key_pair  = "${openstack_compute_keypair_v2.icp-key-pair.name}"
+    network {
+        name = "${var.openstack_network_name}"
+    }
+    user_data = "${data.template_file.bootstrap_init.rendered}"
+}
+
+data "template_file" "bootstrap_init" {
+    template = "${file("scripts/bootstrap_icp_master.sh")}"
+    vars {
+        icp_architecture = "${var.icp_architecture}"
+        docker_download_location = "${var.docker_download_location}"
+        smt_value_master = "${var.smt_value_master}"
+    }
+}
+
+resource "null_resource" "wait_for_master" {
+    provisioner "remote-exec" {
+        connection {
+            host        = "${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"
+            user        = "${var.icp_install_user}"
+            private_key = "${file(var.openstack_ssh_key_file)}"
+            agent       = "false"
+            timeout     = "15m"
+        }
+
+        inline = [
+          "while [ ! -f /tmp/CLOUDINIT_DONE ]; do sleep 5; done",
+        ]
+    }
+}
+
+################################################################
+# Create Worker Nodes
+################################################################
+resource "openstack_compute_instance_v2" "icp_worker_vm" {
+    count     = "${var.icp_num_workers}"
+    depends_on = ["null_resource.wait_for_master"]
+
+    name      = "${format("${var.instance_prefix}-worker-${random_id.rand.hex}-%02d", count.index+1)}"
+    image_id  = "${var.openstack_image_id}"
+    flavor_id = "${var.openstack_flavor_id_worker_node}"
+    key_pair  = "${openstack_compute_keypair_v2.icp-key-pair.name}"
+    network {
+        name = "${var.openstack_network_name}"
+    }
+    user_data = "${data.template_file.bootstrap_worker.rendered}"
+
+    provisioner "remote-exec" {
+        connection {
+            host          = "${self.access_ip_v4}"
+            user          = "${var.icp_install_user}"
+            private_key   = "${file(var.openstack_ssh_key_file)}"
+            agent         = "false"
+            timeout     = "15m"
+        }
+
+        inline = [
+          "while [ ! -f /tmp/CLOUDINIT_DONE ]; do sleep 5; done",
+        ]
+    }
+}
+
+data "template_file" "bootstrap_worker" {
+    template = "${file("scripts/bootstrap_icp_worker.sh")}"
+    vars {
+        docker_download_location = "${var.docker_download_location}"
+    }
+}

--- a/terraform/powervc/main.tf
+++ b/terraform/powervc/main.tf
@@ -1,0 +1,49 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+################################################################
+# Configure the OpenStack Provider
+################################################################
+provider "openstack" {
+    user_name   = "${var.openstack_user_name}"
+    password    = "${var.openstack_password}"
+    tenant_name = "${var.openstack_project_name}"
+    domain_name = "${var.openstack_domain_name}"
+    auth_url    = "${var.openstack_auth_url}"
+    insecure    = true
+}
+
+################################################################
+# Genrate random id for naming
+################################################################
+resource "random_id" "rand" {
+    byte_length = 2
+}
+
+################################################################
+# Configure the OpenStack Keypair
+################################################################
+resource "openstack_compute_keypair_v2" "icp-key-pair" {
+    name       = "terraform-icp-key-pair-${random_id.rand.hex}"
+    public_key = "${file("${var.openstack_ssh_key_file}.pub")}"
+}

--- a/terraform/powervc/outputs.tf
+++ b/terraform/powervc/outputs.tf
@@ -1,0 +1,37 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+#output "icp_master_vm-pub-ip" {
+#    value = "${openstack_compute_floatingip_associate_v2.master_pub_ip.0.floating_ip}"
+#}
+
+output "icp_master_vm_ip" {
+    value = "${openstack_compute_instance_v2.icp_master_vm.network.0.fixed_ip_v4}"
+}
+
+output "icp_worker_vm_ips" {
+    value = "${openstack_compute_instance_v2.icp_worker_vm.*.network.0.fixed_ip_v4}"
+}
+
+output "icp_default_admin_password" {
+    value = "${module.icpprovision.default_admin_password}"
+}

--- a/terraform/powervc/scripts/bootstrap_icp_master.sh
+++ b/terraform/powervc/scripts/bootstrap_icp_master.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Allow SMT levels to be set for the master node
+if [ "${icp_architecture}" == "ppc64le" ] && [ ! -z "${smt_value_master}" ] && [ -f /usr/sbin/ppc64_cpu ]; then
+    /usr/sbin/ppc64_cpu --smt=${smt_value_master}
+    cat >> /etc/systemd/system/smt.service <<EOL
+[Unit]
+Description=Set SMT
+After=syslog.target
+[Service]
+Type=simple
+ExecStart=/usr/sbin/ppc64_cpu --smt=${smt_value_master}
+TimeoutSec=300
+[Install]
+WantedBy=multi-user.target
+EOL
+    /bin/systemctl daemon-reload
+    /bin/systemctl enable smt.service
+fi
+
+# Enable NTP
+/usr/bin/timedatectl set-ntp on
+# Need to set vm.max_map_count to at least 262144
+/sbin/sysctl -w vm.max_map_count=262144
+/bin/echo "vm.max_map_count=262144" | /usr/bin/tee -a /etc/sysctl.conf
+
+if [ -f /etc/redhat-release ]; then
+    # Disable the firewall
+    systemctl stop firewalld
+    systemctl disable firewalld
+    # Make sure we're not running some old version of docker
+    yum -y remove docker docker-engine docker.io
+    yum -y install socat moreutils
+    # Either install the icp docker version or from the repo
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        yum -y install docker-ce
+    fi
+    systemctl start docker
+elif [ -f /etc/SuSE-release ]; then
+    systemctl stop SuSEfirewall2
+    systemctl disable SuSEfirewall2
+    zypper -n remove docker docker-engine docker.io
+    zypper -n install socat moreutils
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        zypper -n install docker
+    fi
+    systemctl start docker
+else
+    /usr/sbin/ufw disable
+    # Prepare the system for updates, install Docker and install Python
+    /usr/bin/apt update
+    # We'll use docker-ce (vs docker.io as ce/ee is what is supported by ICP)
+    /usr/bin/apt-get --assume-yes purge docker
+    /usr/bin/apt-get --assume-yes purge docker-engine
+    /usr/bin/apt-get --assume-yes purge docker.io
+    /usr/bin/apt-get --assume-yes install apt-transport-https moreutils\
+    ca-certificates curl software-properties-common python python-pip
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        # Add Docker GPG key
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        # Add the repo
+        /usr/bin/add-apt-repository \
+        "deb https://download.docker.com/linux/ubuntu \
+         $(lsb_release -cs) stable"
+        /usr/bin/apt update
+        /usr/bin/apt-get --assume-yes install docker-ce
+    fi
+fi
+
+touch /tmp/CLOUDINIT_DONE
+
+exit 0

--- a/terraform/powervc/scripts/bootstrap_icp_worker.sh
+++ b/terraform/powervc/scripts/bootstrap_icp_worker.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Enable NTP
+/usr/bin/timedatectl set-ntp on
+# Need to set vm.max_map_count to at least 262144
+/sbin/sysctl -w vm.max_map_count=262144
+/bin/echo "vm.max_map_count=262144" | /usr/bin/tee -a /etc/sysctl.conf
+
+if [ -f /etc/redhat-release ]; then
+    # Disable the firewall
+    systemctl stop firewalld
+    systemctl disable firewalld
+    # Make sure we're not running some old version of docker
+    yum -y remove docker docker-engine docker.io
+    yum -y install moreutils
+    # Either install the icp docker version or from the repo
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        yum -y install docker-ce
+    fi
+    systemctl start docker
+elif [ -f /etc/SuSE-release ]; then
+    systemctl stop SuSEfirewall2
+    systemctl disable SuSEfirewall2
+    zypper -n remove docker docker-engine docker.io
+    zypper -n install moreutils
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        zypper -n install docker
+    fi
+    systemctl start docker
+else
+    /usr/sbin/ufw disable
+    # Prepare the system for updates, install Docker and install Python
+    /usr/bin/apt update
+    # We'll use docker-ce (vs docker.io as ce/ee is what is supported by ICP)
+    /usr/bin/apt-get --assume-yes purge docker
+    /usr/bin/apt-get --assume-yes purge docker-engine
+    /usr/bin/apt-get --assume-yes purge docker.io
+    /usr/bin/apt-get --assume-yes install apt-transport-https moreutils\
+    ca-certificates curl software-properties-common python python-pip
+    if [ ! -z ${docker_download_location} ]; then
+        TMP_DIR="$(/bin/mktemp -d)"
+        cd "$TMP_DIR"
+        /usr/bin/wget -q "${docker_download_location}"
+        chmod +x *
+        ./*.bin --install
+        /bin/rm -rf "$TMP_DIR"
+    else
+        # Add Docker GPG key
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        # Add the repo
+        /usr/bin/add-apt-repository \
+        "deb https://download.docker.com/linux/ubuntu \
+         $(lsb_release -cs) stable"
+        /usr/bin/apt update
+        /usr/bin/apt-get --assume-yes install docker-ce
+    fi
+fi
+
+touch /tmp/CLOUDINIT_DONE
+
+exit 0

--- a/terraform/powervc/variables.tf
+++ b/terraform/powervc/variables.tf
@@ -1,0 +1,209 @@
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+################################################################
+# Configure the OpenStack Provider
+################################################################
+variable "openstack_user_name" {
+    description = "The user name used to connect to OpenStack"
+    default = "my_user_name"
+}
+
+variable "openstack_password" {
+    description = "The password for the user"
+    default = "my_password"
+}
+
+variable "openstack_project_name" {
+    description = "The name of the project (a.k.a. tenant) used"
+    default = "ibm-default"
+}
+
+variable "openstack_domain_name" {
+    description = "The domain to be used"
+    default = "Default"
+}
+
+variable "openstack_auth_url" {
+    description = "The endpoint URL used to connect to OpenStack"
+    default = "https://<HOSTNAME>:5000/v3/"
+}
+
+
+################################################################
+# Configure the Instance details
+################################################################
+variable "instance_prefix" {
+    description = "Prefix to use in instance names"
+    default = "icp"
+}
+
+variable "openstack_image_id" {
+    description = "The ID of the image to be used for deploy operations"
+    default = "my_image_id"
+}
+
+variable "openstack_flavor_id_master_node" {
+    description = "The ID of the flavor to be used for ICP master node deploy operations"
+    default = "my_flavor_id"
+}
+
+variable "openstack_flavor_id_worker_node" {
+    description = "The ID of the flavor to be used for ICP worker node deploy operations"
+    default = "my_flavor_id"
+}
+
+variable "openstack_network_name" {
+    description = "The name of the network to be used for deploy operations"
+    default = "my_network_name"
+}
+
+variable "openstack_ssh_key_file" {
+    description = "The path to the private SSH key file. Appending '.pub' indicates the public key filename"
+    default = "<path to the private SSH key file>"
+}
+
+
+################################################################
+# Configure ICP details
+################################################################
+variable "icp_install_user" {
+    description = "The user with sudo access across nodes (users section of cloud-init)"
+    default = "ubuntu"
+}
+
+variable "icp_install_user_password" {
+   description = "Password for sudo access (leave empty if using passwordless sudo access)"
+   default = ""
+}
+
+variable "icp_num_workers" {
+    description = "The number of ICP worker nodes to provision"
+    default = 1
+}
+
+variable "icp_version" {
+    description = "ICP version number"
+    default = "3.1.2"
+}
+
+variable "icp_architecture" {
+    description = "x86 or ppc64le"
+    default = "ppc64le"
+}
+
+variable "icp_download_location" {
+    description = "HTTP wget location for ICP Enterprise Edition - ignored for community edition"
+    default = ""
+}
+
+variable "icp_default_admin_password" {
+    description = "Password to use for default admin user"
+    default = "S3cure-icp-admin-passw0rd-default"
+}
+
+variable "icp_management_services" {
+    type = "map"
+    description = "Map of management services to enable/disable in icp config.yaml"
+    default = {
+        "istio" = "disabled"
+        "metering" = "enabled"
+    }
+}
+
+variable "docker_download_location" {
+    description = "HTTP wget location for ICP provided Docker package"
+    default = ""
+}
+
+
+################################################################
+# Configure MCM details
+################################################################
+variable "mcm_download_location" {
+    description = "HTTP wget location for MCM tarball"
+    default = ""
+}
+
+variable "mcm_download_user" {
+    description = "Optional username if authentication required for MCM tarball"
+    default = "-"
+}
+
+variable "mcm_download_password" {
+    description = "Optional password if authentication required for MCM tarball"
+    default = "-"
+}
+
+
+################################################################
+# Configure CAM common details
+################################################################
+variable "cam_version" {
+    default = "3.1.0"
+    description = "Version of Cloud Automation Manager to install"
+}
+
+variable "cam_product_id" {
+    default = ""
+    description = "Product Id text for Cloud Automation Manager (EE)"
+}
+
+################################################################
+# Configure CAM online installation details
+################################################################
+variable "cam_docker_user" {
+    description = "Docker Store user name, needs subscription to CAM"
+    default = ""
+}
+
+variable "cam_docker_password" {
+    description = "Docker Store API key OR password"
+    default = ""
+}
+
+################################################################
+# Configure CAM offline installation details (${cam_docker_user} needs to be empty)
+################################################################
+variable "cam_download_location" {
+    description = "HTTP wget location for CAM tarball"
+    default = ""
+}
+
+variable "cam_download_user" {
+    description = "Optional username if authentication required for CAM tarball"
+    default = "-"
+}
+
+variable "cam_download_password" {
+    description = "Optional password if authentication required for CAM tarball"
+    default = "-"
+}
+
+################################################################
+# Configure SMT level for master node
+################################################################
+variable "smt_value_master" {
+    description = "Number of threads per core. Value can be any of: on, off, 1, 2, 4, 8"
+    default = ""
+}


### PR DESCRIPTION
This code template uses https://github.com/ibm-cloud-architecture/terraform-module-icp-deploy to install ICP. This way need not maintain changes for new ICP releases. Also, it will help to reduce the code and make the current module more extensible for future updates.


* Divide the Terraform code for creating Instances and deploying ICP.
* Instances - the bootstrap code required for setting SMT, docker & NTP.
* ICP deployment - Use module https://github.com/ibm-cloud-architecture/terraform-module-icp-deploy.
* Create and use Terraform module for MCM install and cleanup.
* Create and use Terraform module for CAM install and cleanup.