### PR TITLE
icp 3.2.0 mcm installation

### DIFF
--- a/docs/deploy-openstack-terraform.md
+++ b/docs/deploy-openstack-terraform.md
@@ -1,26 +1,24 @@
-Summary
-=======
+# Summary
 This Terraform module will perform a simple IBM Cloud Private (ICP) deployment. By default, it will install the Community Edition, but you can also configure it to install the Enterprise Edition as well. It is currently setup to deploy an ICP master node (also serves as the boot, proxy, and management node) and a user-configurable number of ICP worker nodes. This module serves as a simple way to provision an ICP cluster within your infrastructure.
+
+You can optionally install [IBM Multicloud Manager](#configure-ibm-multicloud-manager-on-ibm-cloud-private-version-320-and-above) and [IBM Cloud Automation Manager](#configure-ibm-cloud-automation-manager) on the cluster by specifying additional input variables.
 
 For provisioning on PowerVC environment please look at [Deploy in PowerVC using Terraform](deploy-powervc-terraform.md) 
 
-Pre-requisites
-------------
+## Pre-requisites
 * Get access to an OpenStack server instance.
 * If the default SSH user is not the root user, the default user must have password-less sudo access.
 * Install [Terraform](https://www.terraform.io/downloads.html) on your workstation.
 * Refer to ICP documentation for installation pre-requisites. https://www.ibm.com/support/knowledgecenter/en/SSBS6K/product_welcome_cloud_private.html
 
-Supported OS versions
-------------
+## Supported OS versions
 This Terraform deployment supports the following OS images on different platforms. Check ICP documentation for supported system configurations.
 
     * Ubuntu 18.04 LTS and 16.04 LTS
     * Red Hat Enterprise Linux (RHEL) 7.4, 7.5, and 7.6
     * SUSE Linux Enterprise Server (SLES) 12 SP3
     
-Additional image considerations
-------------
+## Additional image considerations
 Ensure that the base image used for deployment have necessary repositories configured to install docker and other packages, or have all the below packages pre-installed.
 * docker-ce (docker for SLES) -  ICP Enterprise Edition users should use the ICP-provided platform specific docker tar ball and the docker_download_location variable in variables.tf to specify the download url.
 * moreutils
@@ -28,8 +26,7 @@ Ensure that the base image used for deployment have necessary repositories confi
 * socat
 * nfs-kernel-server (nfs-utils for RHEL)
 
-Instructions
-------------
+## Instructions
 1. Login to your Terraform workstation.
 2. Clone this repository. (git clone git@github.com:IBM/deploy-ibm-cloud-private.git)
 3. Run `cd deploy-ibm-cloud-private/terraform/openstack/` to change the directory.
@@ -41,10 +38,8 @@ Instructions
 
 See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for next steps.
 
-[Inputs](#inputs)
-------------
-**Configure the OpenStack Provider**
-
+## Inputs
+### Configure the OpenStack Provider
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |openstack_user_name|my_user_name|string|The user name used to connect to OpenStack|
@@ -53,8 +48,7 @@ See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for ne
 |openstack_domain_name|Default|string|The domain to be used|
 |openstack_auth_url|https://<HOSTNAME>:5000/v3/|string|The endpoint URL used to connect to OpenStack|
 
-**Configure the Instance details**
-
+### Configure the Instances
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |instance_prefix|icp|string|Prefix to use in instance names|
@@ -70,35 +64,47 @@ See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for ne
 |openstack_availability_zone|power|string|The name of Availability Zone for deploy operation|
 |openstack_security_groups|["default", "icp-rules"]|list|The list of security groups that exists on Openstack server for deploy operation|
 
-**Configure ICP details**
+**Configure IBM Cloud Private details**
 
+### Configure IBM Cloud Private
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |icp_install_user|ubuntu|string|The user with sudo access across nodes (users section of cloud-init)|
 |icp_install_user_password||string|Password for sudo access (leave empty if using passwordless sudo access)|
 |icp_version|3.1.2|string|ICP version number|
 |icp_download_location||string|HTTP wget location for ICP Enterprise Edition - ignored for community edition|
+|icp_download_location_user||string|Optional username for icp_download_location|
+|icp_download_location_password||string|Optional password for icp_download_location|
 |icp_default_admin_password|S3cure-icp-admin-passw0rd-default|string|Password to use for default admin user|
 |icp_management_services|{<br/>"istio" = "disabled"<br/> "metering" = "enabled"<br/>}|map|Map of management services to enable/disable in icp config.yaml|
 |icp_configuration|{}|map|Map of configuration values for ICP|
 |docker_download_location||string|HTTP wget location for ICP provided Docker package|
 
-**Configure MCM details**
-This is an optional component to install on top of ICP.
-Will enable only if *mcm_download_location* is provided in input variables.
+### Configure IBM Multicloud Manager on IBM Cloud Private Version 3.2.0 and above
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|mcm_install|false|string|Set value to "true" if you need to install MCM 3.2.0 and above|
 
+### Configure IBM Multicloud Manager on IBM Cloud Private Version 3.1.2 and below
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |mcm_download_location||string|HTTP wget location for MCM tarball|
 |mcm_download_user|-|string|Optional username if authentication required for MCM tarball|
 |mcm_download_password|-|string|Optional password if authentication required for MCM tarball|
-|mcm_klusterlet_only|false|string|true if need to install Klusterlet without the Hub cluster(remote)|
+
+### Configure IBM Multicloud Manager Klusterlet on the managed-cluster
+No need to specify below variables if Hub and Klusterlet are on the same cluster (All-in-one installation).
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|mcm_klusterlet_only|false|string|Set to "true" if need to install Klusterlet without the Hub cluster(remote)|
 |mcm_klusterlet_name|mykluster|string|Name of the Klusterlet. Should be unique to each cluster|
 |mcm_namespace|mcm|string|Namespace (unique) on Klusterlet or Hub cluster depending on mcm_klusterlet_only flag|
 |mcm_hub_server_url||string|If mcm_klusterlet_only is true then Hub cluster URL|
 |mcm_hub_server_token||string|If mcm_klusterlet_only is true then Hub cluster Token|
 
-**Configure CAM common details**
+
+### Configure IBM Cloud Automation Manager
 This is an optional component to install on top of ICP.
 Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_download_location* is provided for *Offline Installation* in input variables. *cam_docker_user* should be empty string for *Offline Installation*.
 
@@ -112,14 +118,12 @@ Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_d
 |cam_download_user|-|string|Optional username if authentication required for CAM tarball|
 |cam_download_password|-|string|Optional password if authentication required for CAM tarball|
 
-**Configure SMT level for master node**
-
+### Configure SMT level for master node
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |smt_value_master||string|Number of threads per core. Value can be any of: on, off, 1, 2, 4, 8|
 
-[How-To](#how-to)
-------------
+## How-To
 * **Pass the variables**: There are multiple ways to pass input variables to Terraform module. See [docs](https://www.terraform.io/docs/configuration/variables.html#assigning-values-to-root-module-variables) for more information.
 * **Re-install MCM on the cluster**:
 <br/>`terraform destroy -target=null_resource.mcm_install`
@@ -132,6 +136,5 @@ Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_d
 <br/>`terraform taint -module=cam_install null_resource.cam_install`
 <br/>`terraform destroy`
 
-[Authors](#authors)
-------------
+## Authors
 Yussuf Shaikh yussuf@us.ibm.com

--- a/docs/deploy-powervc-terraform.md
+++ b/docs/deploy-powervc-terraform.md
@@ -1,26 +1,24 @@
-Summary
-=======
+# Summary
 This Terraform module will perform a simple IBM Cloud Private (ICP) deployment. By default, it will install the Community Edition, but you can also configure it to install the Enterprise Edition as well. It is currently setup to deploy an ICP master node (also serves as the boot, proxy, and management node) and a user-configurable number of ICP worker nodes. This module serves as a simple way to provision an ICP cluster within your infrastructure.
+
+You can optionally install [IBM Multicloud Manager](#configure-ibm-multicloud-manager-on-ibm-cloud-private-version-320-and-above) and [IBM Cloud Automation Manager](#configure-ibm-cloud-automation-manager) on the cluster by specifying additional input variables.
 
 For provisioning on OpenStack environment please look at [Deploy in Openstack using Terraform](deploy-openstack-terraform.md)
 
-Pre-requisites
-------------
+## Pre-requisites
 * Get access to a PowerVC server instance.
 * If the default SSH user is not the root user, the default user must have password-less sudo access.
 * Install [Terraform](https://www.terraform.io/downloads.html) on your workstation.
 * Refer to ICP documentation for installation pre-requisites. https://www.ibm.com/support/knowledgecenter/en/SSBS6K/product_welcome_cloud_private.html
 
-Supported OS versions
-------------
+## Supported OS versions
 This Terraform deployment supports the following OS images on different platforms. Check ICP documentation for supported system configurations.
 
     * Ubuntu 18.04 LTS and 16.04 LTS
     * Red Hat Enterprise Linux (RHEL) 7.4, 7.5, and 7.6
     * SUSE Linux Enterprise Server (SLES) 12 SP3
     
-Additional image considerations
-------------
+## Additional image considerations
 Ensure that the base image used for deployment have necessary repositories configured to install docker and other packages, or have all the below packages pre-installed.
 * docker-ce (docker for SLES) -  ICP Enterprise Edition users should use the ICP-provided platform specific docker tar ball and the docker_download_location variable in variables.tf to specify the download url.
 * moreutils
@@ -28,8 +26,7 @@ Ensure that the base image used for deployment have necessary repositories confi
 * socat
 * nfs-kernel-server (nfs-utils for RHEL)
 
-Instructions
-------------
+## Instructions
 1. Login to your Terraform workstation.
 2. Clone this repository. (git clone git@github.com:IBM/deploy-ibm-cloud-private.git)
 3. Run `cd deploy-ibm-cloud-private/terraform/powervc/` to change the directory.
@@ -41,10 +38,8 @@ Instructions
 
 See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for next steps.
 
-[Inputs](#inputs)
-------------
-**Configure the OpenStack Provider**
-
+## Inputs
+### Configure the OpenStack Provider
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |openstack_user_name|my_user_name|string|The user name used to connect to OpenStack|
@@ -53,8 +48,7 @@ See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for ne
 |openstack_domain_name|Default|string|The domain to be used|
 |openstack_auth_url|https://<HOSTNAME>:5000/v3/|string|The endpoint URL used to connect to OpenStack|
 
-**Configure the Instance details**
-
+### Configure the Instances
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |instance_prefix|icp|string|Prefix to use in instance names|
@@ -67,36 +61,45 @@ See [Accessing IBM Cloud Private](/README.md#accessing-ibm-cloud-private) for ne
 |openstack_network_name|my_network_name|string|The name of the network to be used for deploy operations|
 |openstack_ssh_key_file|<path to the private SSH key file>|string|The path to the private SSH key file. Appending '.pub' indicates the public key filename|
 
-
-**Configure ICP details**
-
+### Configure IBM Cloud Private
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |icp_install_user|ubuntu|string|The user with sudo access across nodes (users section of cloud-init)|
 |icp_install_user_password||string|Password for sudo access (leave empty if using passwordless sudo access)|
 |icp_version|3.1.2|string|ICP version number|
 |icp_download_location||string|HTTP wget location for ICP Enterprise Edition - ignored for community edition|
+|icp_download_location_user||string|Optional username for icp_download_location|
+|icp_download_location_password||string|Optional password for icp_download_location|
 |icp_default_admin_password|S3cure-icp-admin-passw0rd-default|string|Password to use for default admin user|
 |icp_management_services|{<br/>"istio" = "disabled"<br/> "metering" = "enabled"<br/>}|map|Map of management services to enable/disable in icp config.yaml|
 |icp_configuration|{}|map|Map of configuration values for ICP|
 |docker_download_location||string|HTTP wget location for ICP provided Docker package|
 
-**Configure MCM details**
-This is an optional component to install on top of ICP.
-Will enable only if *mcm_download_location* is provided in input variables.
+### Configure IBM Multicloud Manager on IBM Cloud Private Version 3.2.0 and above
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|mcm_install|false|string|Set value to "true" if you need to install MCM 3.2.0 and above|
 
+### Configure IBM Multicloud Manager on IBM Cloud Private Version 3.1.2 and below
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |mcm_download_location||string|HTTP wget location for MCM tarball|
 |mcm_download_user|-|string|Optional username if authentication required for MCM tarball|
 |mcm_download_password|-|string|Optional password if authentication required for MCM tarball|
-|mcm_klusterlet_only|false|string|true if need to install Klusterlet without the Hub cluster(remote)|
+
+### Configure IBM Multicloud Manager Klusterlet on the managed-cluster
+No need to specify below variables if Hub and Klusterlet are on the same cluster (All-in-one installation).
+
+| Name | Default | Type | Description |
+|--------------------|---------------|--------|----------------------------------------|
+|mcm_klusterlet_only|false|string|Set to "true" if need to install Klusterlet without the Hub cluster(remote)|
 |mcm_klusterlet_name|mykluster|string|Name of the Klusterlet. Should be unique to each cluster|
 |mcm_namespace|mcm|string|Namespace (unique) on Klusterlet or Hub cluster depending on mcm_klusterlet_only flag|
 |mcm_hub_server_url||string|If mcm_klusterlet_only is true then Hub cluster URL|
 |mcm_hub_server_token||string|If mcm_klusterlet_only is true then Hub cluster Token|
 
-**Configure CAM common details**
+
+### Configure IBM Cloud Automation Manager
 This is an optional component to install on top of ICP.
 Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_download_location* is provided for *Offline Installation* in input variables. *cam_docker_user* should be empty string for *Offline Installation*.
 
@@ -110,14 +113,12 @@ Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_d
 |cam_download_user|-|string|Optional username if authentication required for CAM tarball|
 |cam_download_password|-|string|Optional password if authentication required for CAM tarball|
 
-**Configure SMT level for master node**
-
+### Configure SMT level for master node
 | Name | Default | Type | Description |
 |--------------------|---------------|--------|----------------------------------------|
 |smt_value_master||string|Number of threads per core. Value can be any of: on, off, 1, 2, 4, 8|
 
-[How-To](#how-to)
-------------
+## How-To
 * **Pass the variables**: There are multiple ways to pass input variables to Terraform module. See [docs](https://www.terraform.io/docs/configuration/variables.html#assigning-values-to-root-module-variables) for more information.
 * **Re-install MCM on the cluster**:
 <br/>`terraform destroy -target=null_resource.mcm_install`
@@ -130,6 +131,5 @@ Will enable if *cam_docker_user* is provided for *Online Installation* OR *cam_d
 <br/>`terraform taint -module=cam_install null_resource.cam_install`
 <br/>`terraform destroy`
 
-[Authors](#authors)
-------------
+## Authors
 Yussuf Shaikh yussuf@us.ibm.com

--- a/terraform/modules/mcm/scripts/mcm_load.sh
+++ b/terraform/modules/mcm/scripts/mcm_load.sh
@@ -63,6 +63,10 @@ function load_ppa_archive {
 
     cloudctl catalog load-ppa-archive -a ${mcm_file} \
         --registry ${cluster_name}.icp:8500/kube-system
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "MCM Loading failed" >&2
+        exit 1
+    fi
 }
 
 # Add helm chart

--- a/terraform/modules/mcm/scripts/mcm_upgrade.sh
+++ b/terraform/modules/mcm/scripts/mcm_upgrade.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation for ICP 3.2.0 and above.
+#
+################################################################
+
+# Set HOME env var, populate systemArch, helm init and cloudctl login
+function init_mcm {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    systemArch=$(arch)
+    if [ "${systemArch}" == "x86_64" ]; then systemArch='amd64'; fi
+    
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 --skip-ssl-validation \
+        -u ${icp_admin_user} -p ${icp_admin_user_password} -n kube-system
+    helm repo add mgmt-charts \
+        https://${HUB_CLUSTER_IP}:8443/mgmt-repo/charts \
+        --ca-file ~/.helm/ca.pem \
+        --cert-file ~/.helm/cert.pem \
+        --key-file ~/.helm/key.pem
+}
+
+# Install MultiCloud Manager
+function install_mcm {
+    CHARTNAME=mgmt-charts/ibm-mcm-prod
+    export MCM_HELM_RELEASE_NAME=multicluster-hub
+    helm upgrade --install ${MCM_HELM_RELEASE_NAME} \
+        --timeout 1800 --namespace kube-system \
+        --set compliance.mcmNamespace=${mcm_namespace} \
+        --set tillerIntegration.user=${icp_admin_user} \
+        --set topology.enabled=true \
+        ${CHARTNAME} --tls \
+        --ca-file ~/.helm/ca.pem \
+        --cert-file ~/.helm/cert.pem \
+        --key-file ~/.helm/key.pem
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "MCM installation failed" >&2
+        exit 1
+    fi
+
+    HUB_CLUSTER_URL=`kubectl config view -o \
+        jsonpath="{.clusters[?(@.name==\"${cluster_name}\")].cluster.server}"`
+    HUB_CLUSTER_TOKEN=`kubectl config view -o \
+        jsonpath="{.users[?(@.name==\"${cluster_name}-user\")].user.token}"`
+}
+
+# Install MCM Klusterlet
+function install_mcm_klusterlet {
+    kubectl create namespace ${mcm_namespace}
+    export KUBECONFIG=/tmp/kubeconfig
+    kubectl config set-cluster ${cluster_name} --server=${HUB_CLUSTER_URL} --insecure-skip-tls-verify=true
+    kubectl config set-context ${cluster_name}-context --cluster=${cluster_name}
+    kubectl config set-credentials ${icp_admin_user} --token=${HUB_CLUSTER_TOKEN}
+    kubectl config set-context ${cluster_name}-context --user=${icp_admin_user} --namespace=default
+    kubectl config use-context ${cluster_name}-context
+    unset KUBECONFIG
+
+    kubectl create secret generic klusterlet-bootstrap -n kube-system --from-file=/tmp/kubeconfig
+
+    CHARTNAME=mgmt-charts/ibm-klusterlet
+    export MCMK_HELM_RELEASE_NAME=multicluster-klusterlet
+    helm del --purge ${MCMK_HELM_RELEASE_NAME} --tls
+    helm upgrade --install ${MCMK_HELM_RELEASE_NAME} \
+        --timeout 1800 --namespace kube-system \
+        --set klusterlet.enabled=true \
+        --set global.clusterName=${klusterlet_name} \
+        --set global.clusterNamespace=${mcm_namespace} \
+        --set tillerIntegration.user=${icp_admin_user} \
+        --set tillerIntegration.autoGenTillerSecret=true \
+        ${CHARTNAME} --tls \
+        --ca-file ~/.helm/ca.pem \
+        --cert-file ~/.helm/cert.pem \
+        --key-file ~/.helm/key.pem
+    if [[ $? -gt 0 ]]; then
+        /bin/echo "MCM Klusterlet installation failed" >&2
+        exit 1
+    fi
+}
+
+HUB_CLUSTER_IP=$1
+icp_admin_user=$2
+icp_admin_user_password=$3
+KLUSTERLET_ONLY=$4
+cluster_name=mycluster
+klusterlet_name=$5
+mcm_namespace=$6
+HUB_CLUSTER_URL=$7
+HUB_CLUSTER_TOKEN=$8
+
+/bin/echo
+/bin/echo "Installing MCM.."
+init_mcm
+if [ "${KLUSTERLET_ONLY}" == "false" ]; then
+    install_mcm
+fi
+install_mcm_klusterlet
+/bin/echo "MCM installation completed"

--- a/terraform/modules/mcm/scripts/mcm_upgrade_cleanup.sh
+++ b/terraform/modules/mcm/scripts/mcm_upgrade_cleanup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+################################################################
+# Module to deploy IBM Cloud Private
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed Materials - Property of IBM
+#
+# Copyright (C) 2019 IBM Corporation
+#
+# Yussuf Shaikh <yussuf@us.ibm.com> - Initial implementation.
+#
+################################################################
+
+# Set HOME env var, populate systemArch, helm init and cloudctl login
+function clean_mcm {
+    export HOME=~
+    cd $HOME
+    export HELM_HOME=~/.helm
+
+    helm init --client-only
+    cloudctl login -a https://${HUB_CLUSTER_IP}:8443 --skip-ssl-validation \
+        -u ${icp_admin_user} -p ${icp_admin_user_password} -n kube-system
+
+    export MCM_HELM_RELEASE_NAME=multicluster-hub
+    helm del --purge ${MCM_HELM_RELEASE_NAME} --timeout 1800 --tls
+    kubectl delete pod --grace-period=0 --force --namespace kube-system \
+        -l release=${MCM_HELM_RELEASE_NAME}
+
+    export MCMK_HELM_RELEASE_NAME=multicluster-klusterlet
+    helm del --purge ${MCMK_HELM_RELEASE_NAME} --timeout 1800 --tls
+    kubectl delete pod --grace-period=0 --force --namespace kube-system \
+        -l release=${MCMK_HELM_RELEASE_NAME}
+
+    kubectl delete secret klusterlet-bootstrap -n kube-system
+    kubectl delete namespace ${mcm_namespace}
+
+    rm -f /tmp/kubeconfig
+}
+
+
+HUB_CLUSTER_IP=$1
+icp_admin_user=$2
+icp_admin_user_password=$3
+mcm_namespace=$4
+
+/bin/echo
+/bin/echo "Cleaning MCM.."
+
+clean_mcm
+/bin/echo "MCM cleaning completed"

--- a/terraform/modules/mcm/variables.tf
+++ b/terraform/modules/mcm/variables.tf
@@ -89,3 +89,7 @@ variable "mcm_download_user" {
 variable "mcm_download_password" {
     default = "-"
 }
+
+variable "mcm_install" {
+    default = "false"
+}

--- a/terraform/openstack/deploy.tf
+++ b/terraform/openstack/deploy.tf
@@ -87,6 +87,7 @@ module "mcm_install" {
     icp_version             = "${var.icp_version}"
     icp_admin_user          = "admin"
     icp_admin_user_password = "${module.icpprovision.default_admin_password}"
+    mcm_install             = "${var.mcm_install}"
     klusterlet_only         = "${var.mcm_klusterlet_only}"
     klusterlet_name         = "${var.mcm_klusterlet_name}"
     namespace               = "${var.mcm_namespace}"

--- a/terraform/openstack/variables.tf
+++ b/terraform/openstack/variables.tf
@@ -189,6 +189,16 @@ variable "docker_download_location" {
 ################################################################
 # Configure MCM details
 ################################################################
+# MCM 3.2.0 and above
+################################################################
+variable "mcm_install" {
+    description = "Set value to true if you need to install MCM 3.2.0 and above"
+    default = "false"
+}
+
+################################################################
+# MCM 3.1.2 and below
+################################################################
 variable "mcm_download_location" {
     description = "HTTP wget location for MCM tarball"
     default = ""
@@ -204,6 +214,9 @@ variable "mcm_download_password" {
     default = "-"
 }
 
+################################################################
+# MCM Klusterlet only variables
+################################################################
 variable "mcm_klusterlet_only" {
     description = "true if need to install Klusterlet without the Hub cluster(remote)"
     default = "false"

--- a/terraform/powervc/deploy.tf
+++ b/terraform/powervc/deploy.tf
@@ -85,6 +85,7 @@ module "mcm_install" {
     icp_version             = "${var.icp_version}"
     icp_admin_user          = "admin"
     icp_admin_user_password = "${module.icpprovision.default_admin_password}"
+    mcm_install             = "${var.mcm_install}"
     klusterlet_only         = "${var.mcm_klusterlet_only}"
     klusterlet_name         = "${var.mcm_klusterlet_name}"
     namespace               = "${var.mcm_namespace}"

--- a/terraform/powervc/variables.tf
+++ b/terraform/powervc/variables.tf
@@ -173,6 +173,16 @@ variable "docker_download_location" {
 ################################################################
 # Configure MCM details
 ################################################################
+# MCM 3.2.0 and above
+################################################################
+variable "mcm_install" {
+    description = "Set value to true if you need to install MCM 3.2.0 and above"
+    default = "false"
+}
+
+################################################################
+# MCM 3.1.2 and below
+################################################################
 variable "mcm_download_location" {
     description = "HTTP wget location for MCM tarball"
     default = ""
@@ -188,6 +198,9 @@ variable "mcm_download_password" {
     default = "-"
 }
 
+################################################################
+# MCM Klusterlet only variables
+################################################################
 variable "mcm_klusterlet_only" {
     description = "true if need to install Klusterlet without the Hub cluster(remote)"
     default = "false"


### PR DESCRIPTION
ICP comes pre-installed with basic features of MCM. To enable the user to configure full MCM (Controller & Klusterlet) we need to upgrade the specific charts. Have also kept the code for the older version.